### PR TITLE
Playwright navigation test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+videos/
 
 # Translations
 *.mo

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -3,26 +3,19 @@ def get_menu_titles(page) -> list:
     page.wait_for_load_state()
     menu_list = page.query_selector_all("//*[@class='toctree-wrapper compound']/ul/li/a")
 
-    menu_titles = []
-    for i in menu_list:
-        menu_item = i.as_element().inner_text()
-        menu_titles.append(menu_item)
-
-    return menu_titles
+    return [title.as_element().inner_text() for title in menu_list]
 
 
 def test_check_titles(page):
     menu_list = get_menu_titles(page)
     page.goto("index.html")
     page.wait_for_load_state()
-
     for menu_item in menu_list:
         right_arrow = page.query_selector("//*[@id='relations-next']/a")
         if(right_arrow):
             page.click("//*[@id='relations-next']/a")
             page.wait_for_load_state()
-            page_title = page.title()
-            page_title = page_title.split(" — ")[0]
+            page_title = page.title().split(" — ")[0]
             assert page_title == menu_item
         else:
             break

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,13 @@
+def test_right_arrows(page):
+    page.goto("index.html")
+    while(True):
+        #keeps going to the next page until there is no right arrow 
+        right_arrow = page.query_selector("//*[@id='relations-next']/a")
+        if(right_arrow):
+            page.click("//*[@id='relations-next']/a")
+            page.wait_for_load_state()
+        else: 
+            break
+
+#TODO make a similar test but going from de last page to the previous one until it gets to the first one
+            

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,13 +1,28 @@
-def test_right_arrows(page):
+def get_menu_titles(page) -> list:
     page.goto("index.html")
-    while(True):
-        # Keeps going to the next page until there is no right arrow
+    page.wait_for_load_state()
+    menu_list = page.query_selector_all("//*[@class='toctree-wrapper compound']/ul/li/a")
+
+    menu_titles = []
+    for i in menu_list:
+        menu_item = i.as_element().inner_text()
+        menu_titles.append(menu_item)
+
+    return menu_titles
+
+
+def test_check_titles(page):
+    menu_list = get_menu_titles(page)
+    page.goto("index.html")
+    page.wait_for_load_state()
+
+    for menu_item in menu_list:
         right_arrow = page.query_selector("//*[@id='relations-next']/a")
         if(right_arrow):
             page.click("//*[@id='relations-next']/a")
             page.wait_for_load_state()
+            page_title = page.title()
+            page_title = page_title.split(" — ")[0]
+            assert page_title == menu_item
         else:
             break
-
-# TODO make a similar test but going from de last page
-# to the previous one until it gets to the first one

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,13 +1,13 @@
 def test_right_arrows(page):
     page.goto("index.html")
     while(True):
-        #keeps going to the next page until there is no right arrow 
+        # Keeps going to the next page until there is no right arrow
         right_arrow = page.query_selector("//*[@id='relations-next']/a")
         if(right_arrow):
             page.click("//*[@id='relations-next']/a")
             page.wait_for_load_state()
-        else: 
+        else:
             break
 
-#TODO make a similar test but going from de last page to the previous one until it gets to the first one
-            
+# TODO make a similar test but going from de last page
+# to the previous one until it gets to the first one


### PR DESCRIPTION
## Summary

This PR resolves https://github.com/angelasofiaremolinagutierrez/PyZombis/issues/1
After the Runestone version update it was needed to do a navigation test to check no link or button was broken. This is one basic navigation test that helps to check this. More navigation test can be implemented in the future.

In the attached video you can see how playwright test the next arrow <a> component on the page until it doesn't find it anymore (it is until it gets to the last quiz).

## Checklist

- [x] Variables, function and comments are translated to Spanish
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented
- [x] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots

https://user-images.githubusercontent.com/10239480/121119381-1e9b5f00-c7e1-11eb-940f-2676ab9e9abc.mp4



