### PR TITLE
Make python code be PEP8 compliant for Quiz 1

### DIFF
--- a/_sources/quiz/Quiz1.rst
+++ b/_sources/quiz/Quiz1.rst
@@ -16,20 +16,21 @@ Ejercicio 1
    Haga un programa que pida dos números enteros e imprima la suma de esos dos números. |br|
    
    ~~~~
-   def suma(n,m):
+   def suma(n, m):
 
 
    ====
    from unittest.gui import TestCaseGui
+ 
 
    class myTests(TestCaseGui):
 
        def testOne(self):
            
-           self.assertEqual(suma(24,42), 66,"Esperado: 66")
-           self.assertEqual(suma(17,13), 30,"Esperado: 30")
-           self.assertEqual(suma(-11,6), -5,"Esperado: -5")
-           self.assertEqual(suma(0,9), 9,"Esperado: 9")
+           self.assertEqual(suma(24, 42), 66, "Esperado: 66")
+           self.assertEqual(suma(17, 13), 30, "Esperado: 30")
+           self.assertEqual(suma(-11, 6), -5, "Esperado: -5")
+           self.assertEqual(suma(0, 9), 9, "Esperado: 9")
               
 
    myTests().main()
@@ -50,6 +51,7 @@ Ejercicio 2
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
 
        def testOne(self):
@@ -68,7 +70,8 @@ Ejercicio 3
 .. activecode:: q1_3
    :nocodelens:
 
-   Escriba un programa que lea el número de días, horas, minutos y segundos del usuario. Calcular el total en segundos. |br|
+   Escriba un programa que lea el número de días, horas, minutos y segundos del 
+   usuario. Calcular el total en segundos. |br|
    
    ~~~~
    def tiempo_en_segundos(dias, horas, minutos, segundos):
@@ -77,16 +80,33 @@ Ejercicio 3
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(tiempo_en_segundos(2,5,2,5), 190925,"Esperado: 190925")
-           self.assertEqual(tiempo_en_segundos(10,89,5,0), 1184700,"Esperado: 1184700")
-           self.assertEqual(tiempo_en_segundos(8,0,2,0), 691320,"Esperado: 691320")
-           self.assertEqual(tiempo_en_segundos(0,5,55,6), 21306,"Esperado: 21306")
-              
-
+   
+           self.assertEqual(
+                   tiempo_en_segundos(2, 5, 2, 5),
+                   190925,
+                   "Esperado: 190925"
+           )
+           self.assertEqual(
+                   tiempo_en_segundos(10, 89, 5, 0),
+                   1184700,
+                   "Esperado: 1184700"
+           )
+           self.assertEqual(
+                   tiempo_en_segundos(8, 0, 2, 0),
+                   691320,
+                   "Esperado: 691320"
+           )
+           self.assertEqual(
+                   tiempo_en_segundos(0, 5, 55, 6),
+                   21306,
+                   "Esperado: 21306"
+           )
+   
+   
    myTests().main()
 
 
@@ -96,26 +116,45 @@ Ejercicio 4
 .. activecode:: q1_4
    :nocodelens:
 
-   Haz un programa que calcule un aumento de salario. Debe solicitar el monto del salario y el porcentaje del aumento. Muestra el monto del aumento y el nuevo salario. |br|
+   Haz un programa que calcule un aumento de salario. Debe solicitar el 
+   monto del salario y el porcentaje del aumento. Muestra el monto del 
+   aumento y el nuevo salario. |br|
    
    ~~~~
    def aumento(salario, porcentaje):
-      #devolver los valores en una tupla como: return (aumento, nuevo_salario)
+       #devolver los valores en una tupla como: return (aumento, nuevo_salario)
        
 
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(aumento(30500,10),(3050,33550),"Esperado: 3050 y 33550")
-           self.assertEqual(aumento(10400,25), (2600,13000),"Esperado: 2600 y 13000")
-           self.assertEqual(aumento(50100,8), (4008,54108),"Esperado: 4008 y 54108")
-           self.assertEqual(aumento(25000,3), (750,25750),"Esperado: 750 y 25750")
-              
-
+   
+           self.assertEqual(
+                   aumento(30500, 10),
+                   (3050, 33550),
+                   "Esperado: 3050 y 33550"
+           )
+           self.assertEqual(
+                   aumento(10400, 25),
+                   (2600, 13000),
+                   "Esperado: 2600 y 13000"
+           )
+           self.assertEqual(
+                   aumento(50100, 8),
+                   (4008, 54108),
+                   "Esperado: 4008 y 54108"
+           )
+           self.assertEqual(
+                   aumento(25000, 3),
+                   (750, 25750),
+                   "Esperado: 750 y 25750"
+           )
+   
+   
    myTests().main()
 
 
@@ -125,26 +164,44 @@ Ejercicio 5
 .. activecode:: q1_5
    :nocodelens:
 
-   Solicite el precio de un comerciante y el porcentaje de descuento. Muestre el monto del descuento y el precio a pagar. |br|
+   Solicite el precio de un comerciante y el porcentaje de descuento. 
+   Muestre el monto del descuento y el precio a pagar. |br|
 
    ~~~~
    def precio_con_descuento(precio, porcentaje):
-      #devolver los valores en una tupla como: return (descuento, precio_final)
+       #devolver los valores en una tupla como: return (descuento, precio_final)
        
 
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(precio_con_descuento(100100,10),(10010,90090),"Esperado: (10010,90090)")
-           self.assertEqual(precio_con_descuento(20523,4),(820.92,19702.08),"Esperado: (820.92,19702.08)")
-           self.assertEqual(precio_con_descuento(55566,50),(27783,27783),"Esperado: (27783,27783)")
-           self.assertEqual(precio_con_descuento(75660,24),(18158.4,57501.6),"Esperado: (18158.4,57501.6)")
-              
-
+   
+           self.assertEqual(
+                   precio_con_descuento(100100, 10),
+                   (10010, 90090),
+                   "Esperado: (10010,90090)"
+           )
+           self.assertEqual(
+                   precio_con_descuento(20523, 4),
+                   (820.92, 19702.08),
+                   "Esperado: (820.92,19702.08)"
+           )
+           self.assertEqual(
+                   precio_con_descuento(55566, 50),
+                   (27783, 27783),
+                   "Esperado: (27783,27783)"
+           )
+           self.assertEqual(
+                   precio_con_descuento(75660, 24),
+                   (18158.4, 57501.6),
+                   "Esperado: (18158.4,57501.6)"
+           )
+   
+   
    myTests().main()
 
 
@@ -154,26 +211,28 @@ Ejercicio 6
 .. activecode:: q1_6
    :nocodelens:
 
-   Calcule el tiempo de un viaje en auto. Pregunte por la distancia a recorrer y la velocidad media esperada para el viaje. |br|
+   Calcule el tiempo de un viaje en auto. Pregunte por la distancia a recorrer 
+   y la velocidad media esperada para el viaje. |br|
 
    ~~~~
-   def tiempo(distancia,velocidad):
+   def tiempo(distancia, velocidad):
        
 
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(tiempo(5,5),1,"Esperado: 1")
-           self.assertEqual(tiempo(100,3), 100/3 ,"Esperado: "+ str(100/3))
-           self.assertEqual(tiempo(10500,30),350,"Esperado: 350")
-           self.assertEqual(tiempo(8600,50), 172,"Esperado: 172")
-           self.assertEqual(tiempo(130,200), 0.65,"Esperado: 0.65")
-              
-
+   
+           self.assertEqual(tiempo(5, 5), 1, "Esperado: 1")
+           self.assertEqual(tiempo(100, 3), 100/3, "Esperado: " + str(100/3))
+           self.assertEqual(tiempo(10500, 30), 350, "Esperado: 350")
+           self.assertEqual(tiempo(8600, 50), 172, "Esperado: 172")
+           self.assertEqual(tiempo(130, 200), 0.65, "Esperado: 0.65")
+   
+   
    myTests().main()
 
 
@@ -192,17 +251,38 @@ Ejercicio 7
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(celsius_a_fahrenheit(20),((9 * 20) / 5 )+ 32,"Esperado: 68")
-           self.assertEqual(celsius_a_fahrenheit(68),((9 * 68) / 5 )+ 32 ,"Esperado: 154.4")
-           self.assertEqual(celsius_a_fahrenheit(0), ((9 * 0) / 5 )+ 32,"Esperado: 32")
-           self.assertEqual(celsius_a_fahrenheit(-10), ((9 * -10) / 5 )+ 32,"Esperado: 14")
-           self.assertEqual(celsius_a_fahrenheit(-24), ((9 * -24) / 5 )+ 32,"Esperado: -11.2")
-              
-
+   
+           self.assertEqual(
+                   celsius_a_fahrenheit(20),
+                   ((9 * 20) / 5) + 32,
+                   "Esperado: 68"
+           )
+           self.assertEqual(
+                   celsius_a_fahrenheit(68),
+                   ((9 * 68) / 5) + 32,
+                   "Esperado: 154.4"
+           )
+           self.assertEqual(
+                   celsius_a_fahrenheit(0),
+                   ((9 * 0) / 5) + 32,
+                   "Esperado: 32"
+           )
+           self.assertEqual(
+                   celsius_a_fahrenheit(-10),
+                   ((9 * -10) / 5) + 32,
+                   "Esperado: 14"
+           )
+           self.assertEqual(
+                   celsius_a_fahrenheit(-24),
+                   ((9 * -24) / 5) + 32,
+                   "Esperado: -11.2"
+           )
+   
+   
    myTests().main()
 
 
@@ -221,17 +301,37 @@ Ejercicio 8
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(fahrenheit_a_celsius(21),((21-32)*5)/9,"Esperado: "+str(((21-32)*5)/9))
-           self.assertEqual(fahrenheit_a_celsius(108),((108-32)*5)/9 ,"Esperado: "+str(((108-32)*5)/9))
-           self.assertEqual(fahrenheit_a_celsius(0), ((0-32)*5)/9,"Esperado: "+str(((0-32)*5)/9))
-           self.assertEqual(fahrenheit_a_celsius(-10), ((-10-32)*5)/9,"Esperado "+str(((-10-32)*5)/9))
-           self.assertEqual(fahrenheit_a_celsius(14), ((14-32)*5)/9,"Esperado: "+str(((14-32)*5)/9))
-              
-
+          
+           self.assertEqual(
+                   fahrenheit_a_celsius(21), 
+                   ((21-32)*5)/9, 
+                   "Esperado: " + str(((21-32)*5)/9)
+           )
+           self.assertEqual(
+                   fahrenheit_a_celsius(108), 
+                   ((108-32)*5)/9, 
+                   "Esperado: " + str(((108-32)*5)/9)
+           )
+           self.assertEqual(
+                   fahrenheit_a_celsius(0), 
+                   ((0-32)*5)/9, 
+                   "Esperado: " + str(((0-32)*5)/9)
+           )
+           self.assertEqual(
+                   fahrenheit_a_celsius(-10), 
+                   ((-10-32)*5)/9, 
+                   "Esperado: " + str(((-10-32)*5)/9)
+           )
+           self.assertEqual(
+                   fahrenheit_a_celsius(14), 
+                   ((14-32)*5)/9, "Esperado: " + str(((14-32)*5)/9)
+           )
+             
+   
    myTests().main()
 
 
@@ -241,28 +341,52 @@ Ejercicio 9
 .. activecode:: q1_9
    :nocodelens:
 
-   Escriba un programa que pregunte por la cantidad de kilómetros recorridos por un automóvil alquilado, así como el número de días que ha estado alquilado el coche. Calcule el precio a pagar, sabiendo que el coche cuesta R $ 60,00 por día y R $ 0,15 por km recorrido. |br|
+   Escriba un programa que pregunte por la cantidad de kilómetros recorridos 
+   por un automóvil alquilado, así como el número de días que ha estado alquilado 
+   el coche. Calcule el precio a pagar, sabiendo que el coche cuesta R $ 60,00 
+   por día y R $ 0,15 por km recorrido. |br|
    
    ~~~~
-   def precio(km,dias):
+   def precio(km, dias):
        
 
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(precio(123,3),(0.15*123)+(60*3),"Esperado: "+str((0.15*123)+(60*3)))
-           self.assertEqual(precio(800,4),(0.15*800)+(60*4) ,"Esperado: "+str((0.15*800)+(60*4)))
-           self.assertEqual(precio(60,1), (0.15*60)+(60*1),"Esperado: "+str((0.15*60)+(60*1)))
-           self.assertEqual(precio(90,2), (0.15*90)+(60*2),"Esperado: "+str((0.15*90)+(60*2)))
-           self.assertEqual(precio(1016,7), (0.15*1016)+(60*7),"Esperado: "+str((0.15*1016)+(60*7)))
-              
-
+   
+           self.assertEqual(
+                   precio(123, 3),
+                   (0.15*123) + (60*3),
+                   "Esperado: " + str((0.15*123)+(60*3))
+           )
+           self.assertEqual(
+                   precio(800, 4),
+                   (0.15*800) + (60*4),
+                   "Esperado: " + str((0.15*800)+(60*4))
+           )
+           self.assertEqual(
+                   precio(60, 1),
+                   (0.15*60) + (60*1),
+                   "Esperado: " + str((0.15*60)+(60*1))
+           )
+           self.assertEqual(
+                   precio(90, 2),
+                   (0.15*90) + (60*2),
+                   "Esperado: " + str((0.15*90)+(60*2))
+           )
+           self.assertEqual(
+                   precio(1016, 7),
+                   (0.15*1016) + (60*7),
+                   "Esperado: " + str((0.15*1016)+(60*7))
+           )
+   
+   
    myTests().main()
-
+   
 
 Ejercicio 10
 ------------
@@ -270,25 +394,45 @@ Ejercicio 10
 .. activecode:: q1_10
    :nocodelens:
 
-   Escribe un programa para calcular la reducción en la vida útil de un fumador. Preguntar cantidad de cigarrillos fumados por día y cuántos años ha fumado. Considere que un fumador pierde 10 minutos de vida por cada cigarrillo, calcula cuántos días de vida perderá un fumador. Mostrar los días totales. |br|
+   Escribe un programa para calcular la reducción en la vida útil de un fumador. 
+   Preguntar cantidad de cigarrillos fumados por día y cuántos años ha fumado. 
+   Considere que un fumador pierde 10 minutos de vida por cada cigarrillo, calcula 
+   cuántos días de vida perderá un fumador. Mostrar los días totales. |br|
 
    ~~~~
-   def fumador(cigarrillos,anios):
+   def fumador(cigarrillos, anios):
 
 
    ====
    from unittest.gui import TestCaseGui
 
+
    class myTests(TestCaseGui):
-
+   
        def testOne(self):
-           
-           self.assertEqual(fumador(10,1),((10*1*365)*10)/1440,"Esperado: "+str(((10*1*365)*10)/1440))
-           self.assertEqual(fumador(3,5),((3*5*365)*10)/1440 ,"Esperado: "+str(((3*5*365)*10)/1440))
-           self.assertEqual(fumador(1,8), ((1*8*365)*10)/1440,"Esperado: "+str(((1*8*365)*10)/1440))
-           self.assertEqual(fumador(2,3), ((2*3*365)*10)/1440,"Esperado: "+str(((2*3*365)*10)/1440))
-              
-
+   
+           self.assertEqual(
+                   fumador(10, 1),
+                   ((10*1*365)*10)/1440,
+                   "Esperado: "+str(((10*1*365)*10)/1440)
+           )
+           self.assertEqual(
+                   fumador(3, 5),
+                   ((3*5*365)*10)/1440,
+                   "Esperado: "+str(((3*5*365)*10)/1440)
+           )
+           self.assertEqual(
+                   fumador(1, 8),
+                   ((1*8*365)*10)/1440,
+                   "Esperado: "+str(((1*8*365)*10)/1440)
+           )
+           self.assertEqual(
+                   fumador(2, 3),
+                   ((2*3*365)*10)/1440,
+                   "Esperado: "+str(((2*3*365)*10)/1440)
+           )
+   
+   
    myTests().main()
 
 
@@ -298,7 +442,8 @@ Ejercicio 11
 .. activecode:: q1_11
    :nocodelens:
 
-   Sabiendo que  ``str()`` convierte valores numéricos en cadenas, calcule cuántos dígitos hay en 2 elevados a un millón. |br|
+   Sabiendo que  ``str()`` convierte valores numéricos en cadenas, 
+   calcule cuántos dígitos hay en 2 elevados a un millón. |br|
 
    ~~~~
    def digitos():
@@ -306,6 +451,7 @@ Ejercicio 11
        
    ====
    from unittest.gui import TestCaseGui
+
 
    class myTests(TestCaseGui):
 

--- a/tests/test_quiz1.py
+++ b/tests/test_quiz1.py
@@ -1,13 +1,13 @@
 def test_quiz1_1(page):
     page.goto("quiz/Quiz1.html")
 
-    page.click("text=def suma(n,m):")
+    page.click("text=def suma(n, m):")
 
-    page.press("text=def suma(n,m):", "ArrowDown")
+    page.press("text=def suma(n, m):", "ArrowDown")
 
-    page.press("text=def suma(n,m):", "Tab")
+    page.press("text=def suma(n, m):", "Tab")
 
-    page.type("text=def suma(n,m):", "return n+m")
+    page.type("text=def suma(n, m):", "return n+m")
 
 
     # Run the exercise


### PR DESCRIPTION
## Summary

This PR closes LeoCumpli21/PyZombis#28 by adding the missing spaces between params in the definition functions of quiz 1. Hidden unit tests were also modified to follow PEP8 rules. Finally, the missing space in test_quiz1.py was added so the test doesn't fail.

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots

Proof that the test is working:

https://user-images.githubusercontent.com/80920858/121708274-06576880-ca9d-11eb-9d03-0b21f23c2e5e.mp4

