### PR TITLE
Remove Quiz6 reference from lectures/index

### DIFF
--- a/_sources/lectures/index.rst
+++ b/_sources/lectures/index.rst
@@ -36,7 +36,6 @@ Contents:
    TWP58
    TWP60
    TWP65
-   Quiz6
 
 
 ==================


### PR DESCRIPTION
## Summary

This PR closes LeoCumpli21/PyZombis#34. 
The index in lectures had a reference to Quiz6, the file that was removed and changed into Quiz 2. When building in Runestone, it popped the following error:
`PyZombis\_sources\lectures\index.rst:12: WARNING: toctree contains reference to nonexisting document 'lectures/Quiz6'`.

## Checklist

- [x] Reviewers assigned (all peers & at least 1 mentor)

