### PR TITLE
Add TasteDive exercises to `Hackeando  con Python` lecture

### DIFF
--- a/_sources/lectures/TWP45.rst
+++ b/_sources/lectures/TWP45.rst
@@ -141,7 +141,7 @@ La documentación de la API de `TasteDive <https://tastedive.com/read/api>`_.
 
     En este caso, utilizaremos la librería ``requests`` para hacer la solicitud a la API. La url base 
     es ``"https://tastedive.com/api/similar"``. A esta url se le va a pasar un parámetro ``q`` con el 
-    valor de la artista Dua Lipa. Al final la url se va a ver de la siguiente forma: ``"https://tastedive.com/api/similar?q=dua+lipa"``.
+    valor de la artista Ariana Grande. Al final la url se va a ver de la siguiente forma: ``"https://tastedive.com/api/similar?q=ariana+grande"``.
     Note que después de la url base se escribe un ``?`` para indicar que siguen los parámetros.
 
     ~~~~
@@ -152,7 +152,7 @@ La documentación de la API de `TasteDive <https://tastedive.com/read/api>`_.
     proxy = "https://cors.bridged.cc/"
 
     # Los parámetros que se le pasaran a la url los escribimos dentro de un diccionario
-    parametros = {"q": "dua lipa"}
+    parametros = {"q": "ariana grande"}
 
     # Solicitamos a la api los datos
     respuesta = requests.get(proxy + api_url, params=parametros)
@@ -172,39 +172,34 @@ se transforma a un diccionario de Python. Sin embargo, no es del todo legible. E
 ``json.dumps``.
 
 .. activecode:: ac_l45_4
-    :nocodelens:
-    :language: python
-    :datafile: datosjson.txt
+    :language: python3
+    :python3_interpreter: brython
+    
 
     Ahora vamos a solicitar información de la banda Coldplay. Esta vez vamos a imprimir los datos de forma 
     que sean legibles. Esto lo hacemos con el argumento ``indent`` de la función ``dumps`` de ``json``.
+    Vamos a usar ``urllib`` para hacer la solicitud.
 
     ~~~~
-    import requests
+    import urllib.request
+    import urllib.parse
     import json
 
-    api_url = "https://tastedive.com/api/similar"
+    api_url = "https://tastedive.com/api/similar?"
     proxy = "https://cors.bridged.cc/"
-    parametros = {"q": "coldplay"}
+    # La siguiente línea es para los parámetros de la url.
+    parametros = urllib.parse.urlencode({"q": "coldplay"})
 
-    respuesta = requests.get(proxy + api_url, params=parametros)
-    datos = json.loads(respuesta.text)
+    solicitud = urllib.request.urlopen(proxy + api_url + parametros)
+    datos = json.loads(solicitud.read())
 
     # Imprimimos los datos de forma legible para un usuario
     print(json.dumps(datos, indent=4))
-
-    with open("datosjson.txt", "w") as archivo:
-        archivo.write(json.dumps(datos, indent=4))
 
     # Podemos ver que la api arrojó 20 resultados relacionados con
     # la solicitud
     print(len(datos["Similar"]["Results"]))
 
-
-.. datafile:: datosjson.txt
-    :rows: 10
-    :cols: 80
-    :edit:
 
 |
 

--- a/_sources/lectures/TWP45.rst
+++ b/_sources/lectures/TWP45.rst
@@ -122,6 +122,171 @@ En este ejercicio vamos a acceder a Reddit para obetener datos como los de la si
         print()
 
 
+Probando la API de TasteDive
+============================
+
+TasteDive es una herramienta que:
+
+    le ayuda a descubrir nueva música, películas, programas de televisión, libros, autores, juegos, 
+    podcasts y personas con intereses compartidos.
+    -- TasteDive
+
+En el siguiente ejercicio usaremos la API de TasteDive para buscar obras o artistas similares a otra de nuestra
+elección.
+La documentación de la API de `TasteDive <https://tastedive.com/read/api>`_.
+
+.. activecode:: ac_l45_3
+    :nocodelens:
+    :language: python
+
+    En este caso, utilizaremos la librería ``requests`` para hacer la solicitud a la API. La url base 
+    es ``"https://tastedive.com/api/similar"``. A esta url se le va a pasar un parámetro ``q`` con el 
+    valor de la artista Dua Lipa. Al final la url se va a ver de la siguiente forma: ``"https://tastedive.com/api/similar?q=dua+lipa"``.
+    Note que después de la url base se escribe un ``?`` para indicar que siguen los parámetros.
+
+    ~~~~
+    import requests
+    import json
+
+    api_url = "https://tastedive.com/api/similar"
+    proxy = "https://cors.bridged.cc/"
+
+    # Los parámetros que se le pasaran a la url los escribimos dentro de un diccionario
+    parametros = {"q": "dua lipa"}
+
+    # Solicitamos a la api los datos
+    respuesta = requests.get(proxy + api_url, params=parametros)
+
+    # Ahora imprimimos la url
+    print(respuesta.url)
+    print()
+
+    # Transformamos los datos de formato json a Python
+    datos = json.loads(respuesta.text)
+
+    print(datos)
+    
+
+En el ejemplo anterior pudo apreciar que la API regresa un texto, que si lo pasamos por ``json.loads`` 
+se transforma a un diccionario de Python. Sin embargo, no es del todo legible. Esto se puede solucionar con 
+``json.dumps``.
+
+.. activecode:: ac_l45_4
+    :nocodelens:
+    :language: python
+    :datafile: datosjson.txt
+
+    Ahora vamos a solicitar información de la banda Coldplay. Esta vez vamos a imprimir los datos de forma 
+    que sean legibles. Esto lo hacemos con el argumento ``indent`` de la función ``dumps`` de ``json``.
+
+    ~~~~
+    import requests
+    import json
+
+    api_url = "https://tastedive.com/api/similar"
+    proxy = "https://cors.bridged.cc/"
+    parametros = {"q": "coldplay"}
+
+    respuesta = requests.get(proxy + api_url, params=parametros)
+    datos = json.loads(respuesta.text)
+
+    # Imprimimos los datos de forma legible para un usuario
+    print(json.dumps(datos, indent=4))
+
+    with open("datosjson.txt", "w") as archivo:
+        archivo.write(json.dumps(datos, indent=4))
+
+    # Podemos ver que la api arrojó 20 resultados relacionados con
+    # la solicitud
+    print(len(datos["Similar"]["Results"]))
+
+
+.. datafile:: datosjson.txt
+    :rows: 20
+    :cols: 40
+    :edit:
+
+
+El siguiente ejercicio viene con calificación automática.
+
+.. activecode:: ac_l45_5
+    :nocodelens:
+    :language: python
+
+    Ahora va a preguntar a TasteDive por la película Coco. Entonces el diccionario ``parametros`` debe tener el 
+    valor ``"Coco"`` asignado a la llave ``"q"``. Además, esta vez solo queremos 5 resultados en vez de 20. Para 
+    esto existe un parámetro llamado ``"limit"``, que puede ser asignado al número de resultados que se necesiten. 
+    Otro parámetro que le pasará a la url será ``"info"`` y tendrá el valor de 1. Lo que hará esto es que los 
+    resultados vendrán con un texto extra con información sobre la película.
+
+    Primero, va a solicitar a la API lo descrito anteriormente, y guardará esto en la variable ``solicitud``. Después 
+    asignará los datos a la variable ``datos``. Después va asignar a la variable ``resultados`` el número de 
+    resultados que arrojó la solicitud (como se hizo en el ejemplo anterior). Como pusimos un límite, este número 
+    debe coincidir con el límite.
+
+    Ahora va a crear la lista ``peliculas_similares``. Dentro de ``datos`` usted tiene un diccionario de diccionarios 
+    y listas. Lo que hará será buscar los conjuntos dentro de los cuales se encuentren los nombres de las películas 
+    similares a Coco, y va a agregar a ``peliculas_similares`` el nombre de esas películas. En total deben ser 5. 
+    **Pista**: los datos de las películas se encuentran dentro de ``datos["Similar"]["Results"]``, y la llave para 
+    acceder a ellas es ``"Name"``.
+
+    Por último, va a buscar el número de veces que aparece la palabra ``"Pixar"`` en los textos de información de las 
+    películas relacionadas a Coco. Ese número lo va a guardar en la variable ``pixar``. **Pista**: ``"wTeaser"`` es la 
+    llave que guarda el texto. Esta llave se encuentra en el mismo diccionario que el nombre de las películas.
+
+    ~~~~
+    import requests
+    import json
+
+    api_url = "https://tastedive.com/api/similar"
+    proxy = "https://cors.bridged.cc/"
+
+    # Agregue los parámetros
+    parametros = {}
+    
+    # Complete el código
+    solicitud = 
+    datos = 
+
+    # Asigne la variable resultados 
+    
+    # print(f"resultados: {resultados}")
+    
+    # Cree peliculas_similares
+    # Utilice un for loop para encontrar las peliculas similares y agregarlas
+    # a la variable correspondiente
+
+    # print(f"Pelis: {peliculas_similares} len: {len(peliculas_similares)}")
+
+    pixar = 0
+    # Busque el número de ocurrencias de "Pixar" dentro de los datos
+
+    # print(f"Pixar: {pixar}")
+
+    ====
+    from unittest.gui import TestCaseGui
+
+
+    class myTests(TestCaseGui):
+        def testOne(self):
+            self.assertEqual(
+                solicitud.url,
+                "https://cors.bridged.cc/https://tastedive.com/api/similar?q=Coco&limit=5&info=1",
+                "Probando que la url sea: https://cors.bridged.cc/https://tastedive.com/api/similar?q=Coco&limit=5&info=1",
+            )
+            self.assertEqual(resultados, 5, "Probando que resultados esté asignado correctamente.")
+            self.assertEqual(len(peliculas_similares), 5, "Probando que peliculas_similares sean: 5")
+            self.assertEqual(
+                peliculas_similares,
+                ["Toy Story 3", "Finding Nemo", "Inside Out", "Spirited Away", "Monsters, Inc."],
+                "Esperado: ['Toy Story 3', 'Finding Nemo', 'Inside Out', 'Spirited Away', 'Monsters, Inc.']",
+            )
+            self.assertEqual(pixar, 5, "Probando que pixar esté asignado correctamente.")
+
+
+    myTests().main()
+
+
 .. disqus::
     :shortname: pyzombis
     :identifier: lecture16

--- a/_sources/lectures/TWP45.rst
+++ b/_sources/lectures/TWP45.rst
@@ -1,6 +1,6 @@
-=============================
-Hackeando Facebook con Python
-=============================
+====================
+Hackeando con Python
+====================
 
 
 .. image:: img/TWP10_001.jpeg
@@ -202,10 +202,11 @@ se transforma a un diccionario de Python. Sin embargo, no es del todo legible. E
 
 
 .. datafile:: datosjson.txt
-    :rows: 20
-    :cols: 40
+    :rows: 10
+    :cols: 80
     :edit:
 
+|
 
 El siguiente ejercicio viene con calificación automática.
 
@@ -253,7 +254,7 @@ El siguiente ejercicio viene con calificación automática.
     # print(f"resultados: {resultados}")
     
     # Cree peliculas_similares
-    # Utilice un for loop para encontrar las peliculas similares y agregarlas
+    # Utilice un ciclo for para encontrar las peliculas similares y agregarlas
     # a la variable correspondiente
 
     # print(f"Pelis: {peliculas_similares} len: {len(peliculas_similares)}")

--- a/tests/test_lectureTWP45.py
+++ b/tests/test_lectureTWP45.py
@@ -11,4 +11,52 @@ def test_l45_1(page):
     img_src = iframe.get_attribute("#img_obtenida", "src")
 
     # Test the src attribute from image matches the Facebook URL
-    assert img_src == 'https://graph.facebook.com/ACDC/picture?type=large'
+    assert img_src == "https://graph.facebook.com/ACDC/picture?type=large"
+
+
+def test_l45_5(page):
+    # Go to TWP45 page
+    page.goto("lectures/TWP45.html")
+
+    # Do the exercise
+    page.click("#ac_l45_5 >> text=parametros = {}")
+    # Clear all code
+    page.keyboard.press("Control+A")
+    page.keyboard.press("Backspace")
+
+    instructions1 = [
+        "import requests",
+        "import json",
+        "api_url = 'https://cors.bridged.cc/https://tastedive.com/api/similar'",
+        'parametros = {"q": "Coco", "limit": 5, "info": 1}',
+        "solicitud = requests.get(api_url, params=parametros)",
+        "datos = json.loads(solicitud.text)",
+        'resultados = len(datos["Similar"]["Results"])',
+        "peliculas_similares = []",
+        'for peli in datos["Similar"]["Results"]:',
+        'peliculas_similares.append(peli["Name"])',
+    ]
+
+    for i in instructions1:
+        page.keyboard.type(i)
+        page.keyboard.press("Enter")
+
+    for i in range(4):
+        page.keyboard.press("Backspace")
+
+    instructions2 = [
+        "pixar = 0",
+        'for peli in datos["Similar"]["Results"]:',
+        'for pal in peli["wTeaser"].split():',
+        'if pal == "Pixar":',
+        "pixar += 1",
+    ]
+
+    for i in instructions2:
+        page.keyboard.type(i)
+        page.keyboard.press("Enter")
+
+    # Run and check it passed all tests
+    page.click("#ac_l45_5 >> *css=button >> text=Run")
+    page.hover("#ac_l45_5 >> text=You passed:")
+    assert page.inner_text("#ac_l45_5 >> text=You passed:") == "You passed: 100.0% of the tests"


### PR DESCRIPTION
## Summary

This PR closes LeoCumpli21/PyZombis#11. 

I did the following:
* I changed the title to `Hackeando Python` because it is no longer focused on Facebook only. @NicolasSandoval  suggested the title here: https://github.com/PyAr/PyZombis/pull/113#pullrequestreview-698559530.
* I made 3 new exercises regarding TasteDive API. One of them has unit test for automatic grading.

The exercises teach the basics of accessing an API and using the json module.

**Note**: There's an exercise where `dumps` from json is used and its `indendt` argument is invoked, but Runestone doesn't display the output in a nice indented way, even in a datafile.

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots

https://user-images.githubusercontent.com/80920858/124342393-4cc65180-db89-11eb-8842-cebd547e0b21.mp4


