### PR TITLE
Remove code screenshots and slides titles from lectures TWP05 to TWP38

### DIFF
--- a/_sources/lectures/TWP05.rst
+++ b/_sources/lectures/TWP05.rst
@@ -627,9 +627,6 @@ Prueba de escritorio o simulación
 + Puedes entrenar con lápiz, borrador y papel
 
 
-Prueba de escritorio o simulación
-=================================
-
 .. table:: **Prueba de mesa o simulación**
    :widths: auto
    :align: left
@@ -719,6 +716,9 @@ Utilice el intérprete de modo interactivo aquí abajo para solucionar estos eje
    .. raw:: html
       :file: _static/interpreter.html
 
+.. raw:: html
+   
+   <br/>
 
 .. image:: img/TWP05_041.jpeg
    :height: 12.571cm

--- a/_sources/lectures/TWP05.rst
+++ b/_sources/lectures/TWP05.rst
@@ -687,7 +687,7 @@ Error común
 ===========
 
 + Abrir dos paréntesis y cerrar solo uno.
-+ Esto mismo nos puede ocurrir con las llaves, corchetes, comillas, entre otros caracteres. ``{}``,``[]``,``""`` siempre que abrimos uno debemos acordarnos de cerrarlo.
++ Esto mismo nos puede ocurrir con las llaves, corchetes, comillas, entre otros caracteres. ``{}``, ``[]``, ``" "`` siempre que abrimos uno debemos acordarnos de cerrarlo.
 + El error terminará en lo siguiente:
 
 .. code-block:: python
@@ -703,15 +703,12 @@ Error común
 Lista de Ejercicios
 ===================
 
-#. Su salario actual es de $6500. Haga un programa que
-   calcule su nuevo salario con un aumento del 5%
-#. Escriba un programa que muestre su nombre en la pantalla
+#. Su salario actual es de $6500. Calcule su nuevo salario con un aumento del 5%
+#. Muestre su nombre en la pantalla
 #. Calcule la suma de tres variables
 #. ¿Qué sucede si escribo textos en las tres variables anteriores?
-#. Indique el tipo de los siguientes valores: ``5``, ``5.0``, ``4.3``, ``-2``,
-   ``100``, ``1.333``, ``"10"``
-#. Experimente en el intérprete interactivo de Python utilizar ``type(x)`` donde ``x``
-   es cada uno de los valores anteriores
+#. Indique el tipo de los siguientes valores: ``5``, ``5.0``, ``4.3``, ``-2``, ``100``, ``1.333``, ``"10"``
+#. Experimente en el intérprete interactivo de Python utilizar ``type(x)`` donde ``x`` es cada uno de los valores anteriores
 #. ¿Es posible calcular 2 elevado a un millón?
 
 Utilice el intérprete de modo interactivo aquí abajo para solucionar estos ejercicios.

--- a/_sources/lectures/TWP05.rst
+++ b/_sources/lectures/TWP05.rst
@@ -726,4 +726,4 @@ Utilice el intérprete de modo interactivo aquí abajo para solucionar estos eje
    :align: center
    :alt: 
 
-“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote”. - Einstein

--- a/_sources/lectures/TWP05.rst
+++ b/_sources/lectures/TWP05.rst
@@ -632,15 +632,16 @@ Prueba de escritorio o simulación
 
 .. table:: **Prueba de mesa o simulación**
    :widths: auto
+   :align: left
 
-   ====== ====== ====
-   deuda  compra Tela
-   ====== ====== ====
+   ====== ====== ========
+   deuda  compra Pantalla
+   ====== ====== ========
    -0-    -100-    600
    -100-  -200-
    -300-    300
    600
-   ====== ====== ====
+   ====== ====== ========
 
 
 No tengas prisa por la prueba de escritorio

--- a/_sources/lectures/TWP10.rst
+++ b/_sources/lectures/TWP10.rst
@@ -9,6 +9,7 @@ Condiciones
     :align: center
     :alt:
 
+
 Condiciones
 ===========
 
@@ -25,17 +26,13 @@ Condiciones
 
 + Tus programas no siempre serán simples secuencias de comandos
 
-Condiciones
-===========
 
-+ “¿Correr o no correr? Esa es la cuestión..."
+“¿Correr o no correr? Esa es la cuestión..."
+============================================
+
 + En general no ejecuto todas las líneas del programa.
 + Ir a través de las líneas de un programa es como viajar en automóvil en una ciudad.
 + Hay puntos dónde decidimos qué camino elegir.
-
-
-Condiciones
-===========
 
 .. image:: img/TWP10_004.png
     :height: 13.389cm
@@ -60,15 +57,13 @@ if
 
 
 Dos puntos e identación
-=======================
+***********************
 
-+ En Python es obligatorio culminar cualquier condición con ``:``.
++ Note que en Python es obligatorio culminar cualquier condición (if) con ``:``.
 + Recuerda también identar los bloques de código dentro de las condiciones, es obligatorio.
 
-if
-==
 
-+ Verificar si un auto es nuevo o viejo.
+Verificar si un auto es nuevo o viejo:
 + Si el auto tiene al menos tres años de creado, es nuevo, es viejo en caso contrario.
 
 .. codelens:: cl_l10_3
@@ -79,15 +74,9 @@ if
     if anio_creacion > 3:
         print("Su auto es viejo")
 
-if
-==
-
 + Pregunte la velocidad de un automóvil, suponiendo que es un número entero.
 + En caso de que la velocidad supere los 110 km/h, muestre un mensaje que dice que el usuario ha sido multado.
 + Muestre el monto de la multa si es multado, cobrando ``$5.00`` por cada km por encima de los 110 km/h.
-
-if
-==
 
 .. codelens:: cl_l10_4
 
@@ -96,6 +85,7 @@ if
         print("Usted a sido multado")
         multa = (velocidad - 110) * 5
         print("Valor de la multa : $%5.2f " % multa)
+
 
 if / else
 =========
@@ -142,9 +132,6 @@ Estructuras anidadas
     :align: center
     :alt:
 
-Estructuras anidadas
-====================
-
 + Pueden crearse condiciones anidadas.
 + Recuerda identar las porciones de código que se encuentren anidadas.
 
@@ -161,16 +148,7 @@ Estructuras anidadas
     print("Cuenta telefonica : $%6.2f" % (minutos * precio))
 
 + Note la doble identación para cumplir la segunda condición.
-
-
-Estructuras anidadas
-====================
-
-+ Modificar el programa de la compañía "Chao" para una promoción dónde la tarifa es de ``$0.08`` cuando usa más de 800 minutos.
-
-
-Estructuras anidadas
-====================
++ Ahora modificamos el programa de la compañía "Chao" para una promoción dónde la tarifa es de ``$0.08`` cuando usa más de 800 minutos.
 
 .. codelens:: cl_l10_8
 
@@ -219,5 +197,4 @@ Lista de Ejercicios “again”
     :align: center
     :alt:
 
-+ La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
-
++ “La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote” - Einstein

--- a/_sources/lectures/TWP10.rst
+++ b/_sources/lectures/TWP10.rst
@@ -197,4 +197,4 @@ Lista de Ejercicios “again”
     :align: center
     :alt:
 
-“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote”. - Einstein

--- a/_sources/lectures/TWP10.rst
+++ b/_sources/lectures/TWP10.rst
@@ -197,4 +197,4 @@ Lista de Ejercicios “again”
     :align: center
     :alt:
 
-+ “La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote” - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein

--- a/_sources/lectures/TWP15.rst
+++ b/_sources/lectures/TWP15.rst
@@ -86,13 +86,14 @@ Prueba de escritorio
 
 .. code-block:: python
 
-   x=1
+   x = 1
    while x <= 3:
        print(x)
        x = x + 1
 
 .. table:: **Prueba de escritorio**
    :widths: auto
+   :align: left
 
    ====== ========
      x    Pantalla
@@ -101,7 +102,7 @@ Prueba de escritorio
    -2-    2
    -3-    3
    4
-   ====== ======
+   ====== ========
 
 .. codelens:: cl_l15_5
 
@@ -155,7 +156,7 @@ Contadores
 
 
 Algunos ejercicios
-------------------
+==================
 
 
 .. activecode:: ac_l15_4
@@ -300,7 +301,7 @@ Repeticiones anidadas
    tabla_de_multiplicar = 1
    while tabla_de_multiplicar <= 10:
        n = 1
-       print("tabla_de_multiplicar %d" %tabla_de_multiplicar)
+       print("\nTabla de multiplicar del %d" %tabla_de_multiplicar)
        while  n <= 10:
            print("%d x %d = %d" %(tabla_de_multiplicar, n, tabla_de_multiplicar * n))
            n = n + 1
@@ -314,4 +315,4 @@ Repeticiones anidadas
    :alt: 
 
 
-+ “La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote” - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein

--- a/_sources/lectures/TWP15.rst
+++ b/_sources/lectures/TWP15.rst
@@ -16,11 +16,17 @@ Repeticiones
 .. image:: img/TWP15_001.jpg
    :height: 15.602cm
    :width: 16.801cm
+   :align: center
    :alt: 
+
+.. raw:: html
+   
+   <br/>
 
 .. image:: img/TWP15_002.jpeg
    :height: 19.049cm
    :width: 12.668cm 
+   :align: center
    :alt: 
 
 

--- a/_sources/lectures/TWP15.rst
+++ b/_sources/lectures/TWP15.rst
@@ -27,8 +27,9 @@ Repeticiones
 Impresión de 1 a 3
 ===================
 
-+ Formas  simples
 
+Forma  simple
+*************
 
 .. codelens:: cl_l15_1
 
@@ -37,8 +38,8 @@ Impresión de 1 a 3
    print(3)
 
 
-+ Usando una variable
-
+Usando una variable
+*******************
 
 .. codelens:: cl_l15_2
 
@@ -50,12 +51,8 @@ Impresión de 1 a 3
    print(x)
 
 
-Impresión de 1 a 3
-===================
-
-
-
-+ Incrementando la variable
+Incrementando la variable
+*************************
 
 .. codelens:: cl_l15_3
 
@@ -66,8 +63,8 @@ Impresión de 1 a 3
    x = x + 1
    print(x)
 
-+ Usando ``while``
-
+Usando ``while``
+****************
 
 .. codelens:: cl_l15_4
 
@@ -75,9 +72,6 @@ Impresión de 1 a 3
    while x <= 3:
        print(x)
        x = x +1
-
-Impresión de 1 a 3
-===================
 
 
 .. image:: img/TWP15_007.jpeg
@@ -90,13 +84,24 @@ Impresión de 1 a 3
 Prueba de escritorio
 ====================
 
+.. code-block:: python
 
-.. image:: img/TWP15_Tab1.jpg
-   :height: 6cm
-   :width: 22.181cm
-   :align: center
-   :alt: 
+   x=1
+   while x <= 3:
+       print(x)
+       x = x + 1
 
+.. table:: **Prueba de escritorio**
+   :widths: auto
+
+   ====== ========
+     x    Pantalla
+   ====== ========
+   -1-    1
+   -2-    2
+   -3-    3
+   4
+   ====== ======
 
 .. codelens:: cl_l15_5
 
@@ -105,13 +110,11 @@ Prueba de escritorio
        print(x)
        x = x + 1
 
+
 Contadores
 ==========
 
-
-
 + Ahora imprima de 1 a un número ingresado por el usuario
-
 
 .. activecode:: ac_l15_1
    :nocodelens:
@@ -123,12 +126,7 @@ Contadores
        print(x)
        x = x + 1
 
-Contadores
-==========
-
-
 + Imprima números pares entre 0 y un número dado por el usuario usando ``if``
-
 
 .. activecode:: ac_l15_2
    :nocodelens:
@@ -142,13 +140,8 @@ Contadores
        x = x + 1
 
 
-Contadores
-==========
-
-
 + Imprima números pares entre 0 y un número proporcionado sin usar
   ``if``
-
 
 .. activecode:: ac_l15_3
    :nocodelens:
@@ -206,10 +199,6 @@ Acumuladores
    print("suma: %d" %suma)
 
 
-Acumuladores
-============
-
-
 + Promedio de 10 números enteros
 
 
@@ -227,10 +216,6 @@ Acumuladores
    print("Promedio: %5.2f" %(suma / n))
 
 
-Acumuladores
-============
-
-
 + Calcular el factorial de diez
 
 .. codelens:: cl_l15_6
@@ -241,11 +226,6 @@ Acumuladores
        fact = fact * i
        i = i + 1
    print("Fact(10) = %d" %fact)
-
-
-
-Acumuladores
-============
 
 
 + Calcular el factorial de un número entero ``n``
@@ -284,10 +264,6 @@ Interrumpiendo la repetición
        suma = suma + x
 
    print("Suma: %d" %suma)
-
-
-Interrumpiendo la repetición
-============================
 
 
 + Calcule el promedio de los números ingresados hasta que se ingrese cero

--- a/_sources/lectures/TWP15.rst
+++ b/_sources/lectures/TWP15.rst
@@ -315,4 +315,4 @@ Repeticiones anidadas
    :alt: 
 
 
-“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote”. - Einstein

--- a/_sources/lectures/TWP17.rst
+++ b/_sources/lectures/TWP17.rst
@@ -9,6 +9,7 @@ Listas
     :align: center
     :alt:
 
+
 Edificio
 ========
 
@@ -20,9 +21,6 @@ Edificio
     edificio_1ra_planta = "La Familia Brito"
     edificio_2da_planta = "El Sr Jorge"
     edificio_3ra_planta = "La Familia Tanaka"
-
-Edificio
-========
 
 + Podemos asociar la planta baja con la planta baja, la primera es la planta 1 y etc.
 
@@ -38,6 +36,7 @@ Edificio
     print(edificio[2])
     print(edificio[3])
 
+
 Tren de datos
 =============
 
@@ -47,8 +46,6 @@ Tren de datos
     :align: center
     :alt:
 
-Tren de datos
-=============
 
 ..  image:: img/TWP17_005.png
     :height: 8.2cm
@@ -70,8 +67,8 @@ Puedo enganchar vagones
 
 + ¿Cómo puedo agregar un vagón con "Bettys"?
 
-Puedo conectar los vagones con agregar
-======================================
+Puedo conectar los vagones con el método append()
+=================================================
 
 ..  image:: img/TWP17_007.png
     :height: 8cm

--- a/_sources/lectures/TWP17.rst
+++ b/_sources/lectures/TWP17.rst
@@ -218,4 +218,4 @@ Lista de Ejercícios “again”
     :align: center
     :alt:
 
-“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote”. - Einstein

--- a/_sources/lectures/TWP17.rst
+++ b/_sources/lectures/TWP17.rst
@@ -67,8 +67,8 @@ Puedo enganchar vagones
 
 + ¿Cómo puedo agregar un vagón con "Bettys"?
 
-Puedo conectar los vagones con el método append()
-=================================================
+Puedo unir los vagones con el método append()
+=============================================
 
 ..  image:: img/TWP17_007.png
     :height: 8cm
@@ -98,7 +98,6 @@ Listas
     notas = [7.5, 9, 8.3]
     print(notas[0])
 
-
 + Cambiar la primera nota
 
 ..  codelens:: cd_l17_6
@@ -106,9 +105,6 @@ Listas
     notas = [7.5, 9, 8.3]
     notas[0] = 8.7
     print(notas[0])
-
-Listas
-======
 
 + Promedio de 5 notas
 
@@ -124,9 +120,6 @@ Listas
 
 +  **Nota**: ``x += 1`` es lo mismo que ``x = x + 1``
 
-Listas
-======
-
 + Haga un programa que lea un vector de 5 números enteros y muestre vector.
 
 ..  activecode:: ac_l17_1
@@ -141,8 +134,6 @@ Listas
         i = i + 1
     print("Vector de lectura :", vector)
 
-Listas
-======
 
 + Haga un programa que lea un vector de diez números reales y los muestre en orden inverso
 
@@ -160,9 +151,6 @@ Listas
     while i >= 0:
         print(vector[i])
         i -= 1
-
-Listas
-======
 
 + Haga un programa que lea cuatro notas, muestre las notas y el promedio en pantalla
 
@@ -184,9 +172,6 @@ Listas
     print("Notas:", notas)
     print("Media : %4.2f" % (suma / 4))
 
-Listas
-======
-
 + Otra forma de hacer lo mismo.
 
 ..  activecode:: ac_l17_4
@@ -204,8 +189,6 @@ Listas
     print("Notas:", notas)
     print("Media : %4.2f" % (suma / 4))
 
-Listas
-======
 
 + Haga un programa que lea un vector de 10 caracteres en minúscula, y diga cuántas consonantes se leyeron.
 
@@ -235,5 +218,4 @@ Lista de Ejercícios “again”
     :align: center
     :alt:
 
-+ “La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote” - Einstein
-
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein

--- a/_sources/lectures/TWP17.rst
+++ b/_sources/lectures/TWP17.rst
@@ -67,7 +67,7 @@ Puedo enganchar vagones
 
 + ¿Cómo puedo agregar un vagón con "Bettys"?
 
-Puedo unir los vagones con el método append()
+Puedo unir los vagones con el método ``append()``
 =============================================
 
 ..  image:: img/TWP17_007.png

--- a/_sources/lectures/TWP17.rst
+++ b/_sources/lectures/TWP17.rst
@@ -68,7 +68,7 @@ Puedo enganchar vagones
 + ¿Cómo puedo agregar un vagón con "Bettys"?
 
 Puedo unir los vagones con el método ``append()``
-=============================================
+=================================================
 
 ..  image:: img/TWP17_007.png
     :height: 8cm

--- a/_sources/lectures/TWP18.rst
+++ b/_sources/lectures/TWP18.rst
@@ -9,9 +9,9 @@ Strings
     :align: center
     :alt: 
 
-Comillas de varios tipos.
-=========================
 
+Comillas de varios tipos
+========================
 
 + ¿Puedo usar comillas simples, dobles o triples?
 
@@ -36,9 +36,7 @@ Comillas de varios tipos.
 Rebanar
 =======
 
-
 + Rebanada del primer índice al anterior del segundo
-
 
 .. codelens:: cl_l18_2
          
@@ -48,10 +46,6 @@ Rebanar
     print(x[2:4])
     print(x[0:5])
     print(x[1:8])
-
-
-Rebanar
-========
 
 
 + Podemos omitir índices, sustituyendo el extremo correspondiente y
@@ -80,10 +74,6 @@ Incremento en el corte
     texto = "papa cuando nace"
     print(texto[::2])
     print(texto[::-1])
-
-
-Incremento en el corte
-=======================
 
 
 + Comprobar si una palabra es palíndrome
@@ -128,9 +118,8 @@ Puedo crear nuevos strings
     print(texto)
 
 
-Concentración
+Concatenación
 =============
-
 
 + Ejemplo de un programa que lee una palabra y reemplaza las vocales por ``"*"``.
   La función ``lower`` transforma las letras en minúsculas.
@@ -280,17 +269,11 @@ Ejercicio
 Dojo de codificación
 ====================
 
-
 .. image:: img/TWP18_015.jpeg
     :height: 14.251cm
     :width: 19.001cm
     :align: center
     :alt: 
-
-
-Dojo de codificación
-=====================
-
 
 + Desarrollo basado en pruebas
 + Pasos de bebé

--- a/_sources/lectures/TWP20.rst
+++ b/_sources/lectures/TWP20.rst
@@ -225,4 +225,4 @@ Lista de ejercicios "again"
     :align: center
     :alt:
 
-“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote”. - Einstein

--- a/_sources/lectures/TWP20.rst
+++ b/_sources/lectures/TWP20.rst
@@ -68,8 +68,8 @@ for == while oculto
         print(x)
         k = k + 1
 
-funciones def
-=============
+funciones ``def``
+=================
 
 + Aprendimos algunas funciones de Python: ``len``, ``int``, ``float``, ``print`` e ``input``.
 + Ahora crearemos nuestras propias funciones.
@@ -118,27 +118,20 @@ Variables locales y globales
 
     a = 5
 
-
     def cambio_y_impresion():
         a = 7
-        print("valor de a dentro de la función : %d" % a)
+        print("valor de 'a' dentro de la función : %d" % a)
 
 
-    print("valor de a antes de cambiar: %d" % a)
+    print("valor de 'a' antes de cambiar: %d" % a)
     cambio_y_impresion()
-    print("valor de a después de cambiar: %d" % a)
-
-
-
-Variables locales y globales
-============================
+    print("valor de 'a' después de cambiar: %d" % a)
 
 + En este caso, usamos la palabra reservada global. Entonces, la variable ``a`` dentro de la función es la misma que la variable definida anteriormente, es decir, es la variable global.
 
 .. codelens:: cl_l20_10
          
     a = 5
-
 
     def cambio_y_impresion():
         global a
@@ -175,11 +168,8 @@ Números aleatorios
     print(alumnos)
 
 
-Números al azar
-===============
-
-+ Defina una función de "codificación" que devuelva las letras en una cadena mezclados.
-+ **Consejo**: use ``list()`` para convertir su cadena en una lista.
++ Se define una función de "codificación" que devuelve las letras en una cadena mezclados.
++ **Nota**: Se usa la función ``list()`` para convertir una cadena en una lista.
 
 .. codelens:: cl_l20_12
          
@@ -196,8 +186,6 @@ Números al azar
     print(codificación("palmeras"))
     print(codificación("palmeras"))
 
-Números aleatorios
-==================
 
 + Genere una lista de 15 enteros aleatorios entre 10 y 100.
 
@@ -212,8 +200,6 @@ Números aleatorios
             )
     print(lista)
 
-Números aleatórios
-==================
 
 + Genere una lista de 15 enteros aleatorios entre 10 y 100 que son distintos el uno del otro.
 
@@ -239,6 +225,4 @@ Lista de ejercicios "again"
     :align: center
     :alt:
 
-+ “La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
-
-
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein

--- a/_sources/lectures/TWP20.rst
+++ b/_sources/lectures/TWP20.rst
@@ -1,6 +1,6 @@
-=====================
-For, Funciones y Azar
-=====================
+=======================
+for, random y funciones
+=======================
 
 
 .. image:: img/TWP10_001.jpeg
@@ -30,8 +30,6 @@ for == while oculto
         print(letra)
         k = k + 1
 
-for == while oculto
-====================
 
 + Códigos equivalentes :
 
@@ -49,8 +47,6 @@ for == while oculto
         print(i)
         k = k + 1
 
-for == while oculto
-====================
 
 + Códigos equivalentes :
 

--- a/_sources/lectures/TWP23.rst
+++ b/_sources/lectures/TWP23.rst
@@ -413,4 +413,4 @@ Diccionarios
     :alt: 
 
 
-+ “La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein

--- a/_sources/lectures/TWP23.rst
+++ b/_sources/lectures/TWP23.rst
@@ -413,4 +413,4 @@ Diccionarios
     :alt: 
 
 
-“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote ”. - Einstein
+“La vida es como andar en bicicleta. Para mantener el equilibrio, debes seguir moviéndote”. - Einstein

--- a/_sources/lectures/TWP25.rst
+++ b/_sources/lectures/TWP25.rst
@@ -9,15 +9,13 @@ Clases y objetos
     :align: center
     :alt:
 
+
 Clases y objetos
 =================
 
 + Las clases asocian datos (atributos) y operaciones (métodos) en una estructura.
 + Un objeto es una variable cuyo tipo es una clase, es decir, un objeto es una instancia de una clase.
 + Solo veremos los conceptos básicos de la programación orientada a objetos.
-
-Clases y objetos
-=================
 
 ..  codelens:: cl_l25_1
          
@@ -36,24 +34,14 @@ Clases y objetos
     print(tv_sala.conectado)
     print(tv_sala.canal)
 
-Clases y objetos
-================
-
 + Cuando declaramos una clase, estamos creando un nuevo tipo de datos.
 + Al igual que cuando creamos una lista o una cadena, estamos creando instancias o creando una instancia de estas clases.
 + Es lo mismo hacer ``list = []`` o ``list = list ()``
 + El método ``__init__`` se llama constructor y se llama al crear el objeto.
-
-Clases y objetos
-================
-
 + El parámetro ``self`` significa el objeto de televisión en sí.
 + ``self.conectado`` es un valor del objeto ``television``.
 + Siempre que queramos crear atributos de un objeto, debemos asociarlos con uno mismo utilizando ``self``.
 + De lo contrario, si escribimos solamente ``conectado = False``, ``conectado`` sería solo una variable local del método y no un atributo.
-
-Clases y objetos
-================
 
 ..  codelens:: cl_l25_2
          
@@ -76,14 +64,13 @@ Clases y objetos
     tv.cambiar_canal_hacia_abajo()
     print(tv.canal)
 
-Clases y objetos
-================
 
 + Automatizaras el banco TATU, controlando el saldo de las cuentas corriente.
 + Cada cuenta corriente puede tener uno o más clientes como titular.
 + El banco controla solo el nombre y el número de teléfono.
 + La cuenta corriente muestra un saldo y un estado de cuenta de las operaciones de retiro y depósito.
 + No hay cuentas especiales, por lo que el cliente no puede retirar más de lo que tiene de saldo.
+
 
 Clase Cliente y Clase Cuenta
 ============================
@@ -119,7 +106,6 @@ Clase Cliente y Clase Cuenta
 Utilizando las clases Cliente y Cuenta
 ======================================
 
-
 ..  activecode:: ac_l25_2
     :nocodelens:
     :stdin:
@@ -135,11 +121,13 @@ Utilizando las clases Cliente y Cuenta
     cuenta_1.resumen()
     cuenta_2.resumen()
 
+
 Declaración de operaciones
 ==========================
 
 + Agregue el método ``estado_de_cuenta`` a la clase ``Cuenta`` el cual imprime una lista de las operaciones de retiro y depósito realizadas.
 + Cambie el método ``__init__`` para usar el método ``depositar`` para inicializar el saldo.
+
 
 Clase Cliente y Clase Cuenta (Mejorada)
 =======================================
@@ -205,6 +193,7 @@ Utilizando las clases Cliente y Cuenta (Mejorada)
     cuenta_1.estado_de_cuenta()
     cuenta_2.estado_de_cuenta()
 
+
 Herencia
 ========
 
@@ -233,13 +222,12 @@ Clase Cuenta Especial
             else:
                 print("Saldo insuficiente para retirar")
 
-Clase Cuenta Especial
-=====================
 
 + Tenga en cuenta que escribimos ``Cuenta`` entre paréntesis.
 + ``CuentaEspecial`` hereda los métodos y atributos de ``Cuenta``.
 + ``self.limite`` se creará solo para clases de tipo ``CuentaEspecial``.
 + Tenga en cuenta que estamos sobre escribiendo completamente el método ``retirar`` en ``CuentaEspecial``.
+
 
 Utilizando todas las clases
 ===========================
@@ -263,12 +251,14 @@ Utilizando todas las clases
     cuenta_1.estado_de_cuenta()
     cuenta_2.estado_de_cuenta()
 
+
 Ventajas de la herencia
 =======================
 
 + Hemos modificado muy poco nuestro programa, manteniendo la funcionalidad anterior y agregando nuevas características.
 + Fue posible reutilizar los métodos de la cuenta.
 + Por lo tanto, la definición de la clase ``CuentaEspecial`` fue mucho más simple, incluyendo solo el comportamiento diferente.
+
 
 Otros ejemplos de POO
 =====================
@@ -307,6 +297,7 @@ Otros ejemplos de POO
     :include: ac_l25_7
 
     # Crea un objeto con tu nombre
+
 
 Múltiple herencia y ¿Qué objeto es?
 ===================================

--- a/_sources/lectures/TWP33.rst
+++ b/_sources/lectures/TWP33.rst
@@ -15,6 +15,7 @@ Revisión de String
 + Busquemos dónde está la información en un texto.
 + Y aprenderemos uno de los conceptos más importantes de orientación a la objetos: métodos
 
+
 Starbuzz Café
 =============
 
@@ -53,17 +54,21 @@ El CEO solo quiere el precio
 + Este es el texto HTML "en bruto", que es el formato de las páginas web.
 + El precio está incrustado en HTML
 
+.. code-block:: html
 
-.. image:: img/TWP33_002.png
-    :height: 5.727cm
-    :width: 24.005cm
-    :align: center
-    :alt:
+    <html><head><title>Welcome to the Beans'R'Us Pricing Page</title>
+    <link rel="stylesheet" type="text/css" href="beansrus.css" />
+    </head><body>
+    <h2>Welcome to the Beans'R'Us Pricing Page</h2>
+    <p>Current price of coffee beans = <strong>$6.73</strong></p>
+    <p>Price valid for 15 minutes from Sun Jul 11 03:08:01 2021.</p>
+    </body></html>
+
 
 Strings
 =======
 
-+ String y las cadenas de caracteres.
++ Recibimos el output anterior como una string o cadena de caracteres.
 
 .. image:: img/TWP33_005.png
     :height: 2.112cm
@@ -79,8 +84,6 @@ Strings
     :align: center
     :alt:
 
-Strings
-=======
 
 .. image:: img/TWP33_007.jpg
     :height: 5cm
@@ -94,9 +97,6 @@ Strings
     :width: 16.483cm
     :align: center
     :alt:
-
-Strings
-=======
 
 .. image:: img/TWP33_009.jpg
     :height: 7.317cm
@@ -115,22 +115,14 @@ Cortar
     print(texto[0:3])
     print(texto[4:6])
 
-
 + Corta el primer número antes del segundo.
 + ¡No incluye el segundo número!
-
-Cortar
-======
 
 .. image:: img/TWP33_012.jpg
     :height: 10.323cm
     :width: 19.483cm
     :align: center
     :alt:
-
-
-Cortar
-======
 
 .. activecode:: ac_l33_2
     :nocodelens:
@@ -142,6 +134,7 @@ Cortar
     pagina = urlopen(URL_PRECIOS)
     texto = pagina.read()
     print(texto[234:238])
+
 
 ¡El CEO está feliz!
 ===================
@@ -171,6 +164,7 @@ No hay preguntas tontas
     import antigravity
     # Ejecuta este codigo
 
+
 Descuentos para clientes leales
 ===============================
 
@@ -197,6 +191,7 @@ Programa de fidelización
 
 + ¡No funcionó! la cadena "Bean" apareció en lugar del precio. ¿Por qué sera?
 
+
 El precio se movió
 ==================
 
@@ -221,6 +216,7 @@ Los datos de Python son inteligentes
     print(texto.upper())
     print(texto.split())
 
+
 Método ``find``
 ===============
 
@@ -232,9 +228,6 @@ Método ``find``
     print(texto.find("P"))
     print(texto.find("lmer"))
     print(texto.find("Pa"))
-
-Método ``find``
-===============
 
 .. activecode:: ac_l33_5
     :nocodelens:
@@ -258,10 +251,6 @@ Solo cuando es inferior a 4,74
     :width: 8.6cm
     :align: center
     :alt:
-
-
-Solo cuando es inferior a 4,74
-===============================
 
 .. activecode:: ac_l33_6
     :nocodelens:
@@ -385,6 +374,7 @@ Biblioteca ``time``
 + Duerme unos segundos, ``sleep(segundos)``
 + Zona horaria ``time.timezone()``
 
+
 10 minutos entre cada acceso
 ============================
 
@@ -417,6 +407,7 @@ Resumen
 + Los métodos son funciones integradas en variables.
 + Hay bibliotecas de programación con código listo.
 + Los datos tienen un tipo, como ``int`` o ``string``.
+
 
 Herramientas de Python
 ======================

--- a/_sources/lectures/TWP35.rst
+++ b/_sources/lectures/TWP35.rst
@@ -19,19 +19,11 @@ Seamos más organizados
     :align: center
     :alt: 
 
-
-Seamos más organizados
-======================
-
-
 .. image:: img/TWP35_002.jpeg
     :height: 14.064cm
     :width: 16.601cm
     :align: center
     :alt: 
-
-Seamos organizados
-==================
 
 + Cuando los programas crecen, el código generalmente se vuelve más complejo
 + Una forma de gestionar esta complejidad es usar funciones
@@ -42,7 +34,6 @@ Seamos organizados
 Starbuzz no tiene granos
 ========================
 
-
 + El director de Starbuzz quiere una opción para comprar rápidamente, sin esperar
   a que baje el precio
 + Al ejecutar el programa, te preguntaré si quieres comprar ahora o no
@@ -52,7 +43,6 @@ Starbuzz no tiene granos
 
 Nueva sugerencia de programa
 ============================
-
 
 .. activecode:: ac_l35_1
     :nocodelens:

--- a/_sources/lectures/TWP37.rst
+++ b/_sources/lectures/TWP37.rst
@@ -9,6 +9,7 @@ Revisión de Archivos, Listas y Diccionarios
     :align: center
     :alt:
 
+
 Campeonato de Surf de Codeville
 ===============================
 
@@ -18,25 +19,18 @@ Campeonato de Surf de Codeville
     :align: center
     :alt:
 
-
-Campeonato de Surf de Codeville 
-===============================
-
 ..  image:: img/TWP37_002.jpeg
     :height: 11.923cm
     :width: 17.85cm
     :align: center
     :alt:
 
-
-Campeonato de Surf de Codeville
-===============================
-
 ..  image:: img/TWP37_003.jpeg
     :height: 12.571cm
     :width: 16.762cm
     :align: center
     :alt:
+
 
 Encuentra la puntuación más alta
 ================================
@@ -74,6 +68,7 @@ Leer el archivo ``surf.txt``
     for linea in archivo:
         print(linea.strip())
     archivo.close()
+
 
 Fragmentador for
 ================
@@ -183,6 +178,7 @@ Ordenar la lista sería mejor
     :align: center
     :alt:
 
+
 Ordenar es más fácil en la memoria
 ==================================
 
@@ -201,8 +197,8 @@ Primero: lea los datos en la memoria
     :alt:
 
 
-Wow, vampiro usa un tren de datos
-=================================
+Wow, usemos un tren de datos
+============================
 
 + Matriz, lista, vector son nombres comunes para un lote completo de datos.
 + Solo necesito una sola variable para todo el tren de datos.
@@ -264,14 +260,13 @@ Ordenar en orden descendente
 Métodos ``sort`` y ``reverse``
 ==============================
 
-
 + El método ``sort`` ordena los datos.
 + El uso de ``reverse`` para mantenerlos en orden descendente.
 + Es más inteligente usar ``puntuaciones.sort(reverse = True)``
 
+
 Finalmente las posiciones correctas
 ===================================
-
 
 ..  activecode:: ac_l37_5
     :nocodelens:
@@ -298,6 +293,7 @@ Finalmente las posiciones correctas
     :align: center
     :alt:
 
+
 ¿Cuáles son los nombres de los ganadores?
 =========================================
 
@@ -306,6 +302,7 @@ Finalmente las posiciones correctas
     :width: 16.645cm
     :align: center
     :alt:
+
 
 Usando otra lista
 =================
@@ -335,6 +332,7 @@ Usando otra lista
     print(f"2. {nombres[1]} {puntuaciones[1]:.2f}")
     print(f"3. {nombres[2]} {puntuaciones[2]:.2f}")
 
+
 ¡Pero estos datos son incorrectos!
 ==================================
 
@@ -344,6 +342,7 @@ Usando otra lista
 + Se pierde la correspondencia de las puntuaciones y los nombres de los participantes.
 + Necesario otra estructura de datos para no perder la correspondencia.
 
+
 Necesitamos unir las listas
 ===========================
 
@@ -352,6 +351,7 @@ Necesitamos unir las listas
     :width: 17.645cm
     :align: center
     :alt:
+
 
 Usando y ordenando un diccionario
 =================================

--- a/_sources/lectures/TWP38.rst
+++ b/_sources/lectures/TWP38.rst
@@ -9,9 +9,9 @@ Revisión general 2
     :align: center
     :alt: 
 
+
 ¿Qué es un programa?
 ====================
-
 
 + Un conjunto detallado de instrucciones, paso a paso, que le dice a la 
   computadora qué hacer.
@@ -26,7 +26,6 @@ Revisión general 2
 ¿Qué es un programa?
 ====================
 
-
 + El software (programas) controla el hardware
 
 + El proceso de creación de software se llama programación
@@ -37,7 +36,6 @@ Revisión general 2
 
 Lenguajes de programación
 =========================
-
 
 + Los idiomas de bajo nivel son los más cercanos a la máquina
 
@@ -52,7 +50,6 @@ Lenguajes de programación
 Lenguajes de programación
 =========================
 
-
 + Comando original en lenguaje de alto nivel: C = A + B
 
 + Los compiladores convierten el lenguaje de alto nivel al lenguaje de
@@ -65,18 +62,11 @@ Lenguajes de programación
 Python
 ======
 
-
-
-
 .. codelens:: cl_l38_1
          
     print("hola mundo!")
     print(2 + 3)
     print("2 + 3 = ", 2 + 3)
-
-
-Python
-======
 
 
 + Por lo general, queremos repetir una serie de comandos varias veces
@@ -91,7 +81,6 @@ Python
 
 
     amo_dos_puntos()
-
 
 
 + ¡No olvide los paréntesis cuando llames a la función!
@@ -110,12 +99,7 @@ Python
     print(print)
 
 
-Python
-======
-
-
 + Podemos poner parámetros en una función
-
 
 .. codelens:: cl_l38_4
          
@@ -126,10 +110,6 @@ Python
     print(suma("aguacate", "jabuticaba"))
     print(suma(2, 3))
     print(suma(3.14, 2.71))
-
-
-Python
-======
 
 
 + Las funciones dejan de existir en cuanto sale del intérprete
@@ -143,16 +123,50 @@ Python
 + Puede editar los módulos en un entorno de desarrollo, que
   resalta palabras reservadas, realiza identificación automática, etc.
 
-
-Python
-======
-
-
 + Guardamos un programa llamado ``caos.py``
 
 + No olvides la extensión ``.py``
 
-+ Podemos ejecutar el programa con la tecla F5
++ Podemos ejecutar el programa con el botón de ``Run``
+
++ Las líneas que comienzan con **"#"** se llaman comentarios
+
++ Están destinados a ser leídos por humanos y Python los ignora
+
++ Python omite todo el texto desde el **"#"** hasta el final de la línea
+
+
+.. code-block:: python
+
+   # Archivo caos.py
+   # Un programa que ilustra la Teoria del caos
+
++ ``x`` es un ejemplo de una variable
+
++ En ``x`` asignaremos un valor al que se puede hacer referencia más adelante
+
++ Se mostrará el mensaje entre comillas y la respuesta se almacenará en ``x``
+
+.. code-block:: python
+
+   x = eval(input("Ingrese un número entre 0 y 1:"))
+
++ Hay comandos de bucle o ciclos como el comando ``for``
+
++ Un bucle o ciclo se usa para repetir un bloque de código varias veces
+
++ En este ejemplo, el siguiente bloque se repetirá 10 veces
+
+.. code-block:: python
+
+   for i in range(10):
+
++ Llamamos **sangría** a los espacios al comienzo de la línea 
+
++ En Python, la sangría delimita el bloque que se ejecutará
+
++ El cálculo ``3.9 * x * (1-x)`` se realizará en la CPU y se asignará a la variable
+  ``x``
 
 
 .. activecode:: ac_l38_1
@@ -166,98 +180,27 @@ Python
         print("%2.3f" % x)
 
 
-Python
-======
-
-
-+ Las líneas que comienzan con **"#"** se llaman comentarios
-
-+ Están destinados a ser leídos por humanos y Python los ignora
-
-+ Python omite todo el texto desde el **"#"** hasta el final de la línea
-
-
-.. image:: img/TWP38_008.png
-    :height: 2.173cm
-    :width: 23.602cm
-    :align: center
-    :alt: 
-
-
-Python
-======
-
-
-+ ``x`` es un ejemplo de una variable
-
-+ En ``x`` asignaremos un valor al que se puede hacer referencia más adelante
-
-+ Se mostrará el mensaje entre comillas y la respuesta se almacenará en ``x``
-
-
-.. image:: img/TWP38_009.png
-    :height: 0.799cm
-    :width: 23.316cm
-    :align: center
-    :alt: 
-
-
-Python
-======
-
-
-+ Hay comandos de bucle o ciclos como el comando ``for``
-
-+ Un bucle o ciclo se usa para repetir un bloque de código varias veces
-
-+ En este ejemplo, el siguiente bloque se repetirá 10 veces
-
-
-.. image:: img/TWP38_010.png
-    :height: 1.399cm
-    :width: 13.067cm
-    :align: center
-    :alt: 
-
-
-Python
-======
-
-
-+ Llamamos **sangría** a los espacios al comienzo de la línea 
-
-+ En Python, la sangría delimita el bloque que se ejecutará
-
-+ El cálculo ``3.9 * x * (1-x)`` se realizará en la CPU y se asignará a la variable
-  ``x``
-
-
-.. image:: img/TWP38_011.png
-    :height: 3.599cm
-    :width: 13.694cm
-    :align: center
-    :alt: 
-
-
-Python
-======
-
-
-+ La función de caos devuelve valores muy diferentes, incluso cuando la entrada
-  es similar
++ El programa de caos devuelve valores muy diferentes, incluso cuando la entrada es similar
 
 
 Ejercicio
 =========
 
-
 + Cambie el programa anterior para que pueda ingresar un valor e ingresar
   correr por n veces en lugar del valor 10
 
+.. activecode:: ac_l38_2
+    :language: python3
+    :python3_interpreter: brython
+
+    print("Este programa ilustra el comportamiento caótico.")
+    x = eval(input("Ingrese un número entre 0 y 1:"))
+    for i in range(10):
+        x = 3.9 * x * (1 - x)
+        print("%2.3f" % x)
 
 Resumen
 =======
-
 
 + La descripción de una secuencia de pasos para resolver un problema se llama
   algoritmo computacional.
@@ -270,7 +213,6 @@ Resumen
 
 Recuerde
 ========
-
 
 + Los lenguajes de programación tienen una sintaxis formal
 

--- a/_sources/lectures/TWP38.rst
+++ b/_sources/lectures/TWP38.rst
@@ -15,46 +15,27 @@ Revisión general 2
 
 + Un conjunto detallado de instrucciones, paso a paso, que le dice a la 
   computadora qué hacer.
-
 + Si cambiamos el programa, la computadora hará algo diferente
-
 + La computadora permanece igual, pero el programa ha cambiado
-
 + Los programas se ejecutan
-
-
-¿Qué es un programa?
-====================
-
 + El software (programas) controla el hardware
-
 + El proceso de creación de software se llama programación
-
-+ Un algoritmo es la receta, paso a paso, que resuelve un problema.
-  computacional
++ Un algoritmo es la receta, paso a paso, que resuelve un problema computacional
 
 
 Lenguajes de programación
 =========================
 
 + Los idiomas de bajo nivel son los más cercanos a la máquina
-
 + Ensamblador:
 
   + Cargue el número de variables A en la CPU
   + Cargue el número de variables B en la CPU
   + Agregar los dos números en la CPU
   + Almacenar el resultado en la variable C
-
-
-Lenguajes de programación
-=========================
-
 + Comando original en lenguaje de alto nivel: C = A + B
-
 + Los compiladores convierten el lenguaje de alto nivel al lenguaje de
   máquina informática específica
-
 + Los intérpretes analizan y ejecutan el programa instrucción por
   instrucción del lenguaje de máquina
 
@@ -70,7 +51,6 @@ Python
 
 
 + Por lo general, queremos repetir una serie de comandos varias veces
-
 + Una forma de hacer esto es usar una función
 
 .. codelens:: cl_l38_2
@@ -84,7 +64,6 @@ Python
 
 
 + ¡No olvide los paréntesis cuando llames a la función!
-
 + Si olvida los paréntesis, python devolverá la dirección en
   memoria donde se encuentra definida la función.
 
@@ -114,27 +93,22 @@ Python
 
 + Las funciones dejan de existir en cuanto sale del intérprete
   Python
-
 + Por lo tanto, los programas generalmente se componen de módulos, que son
   archivos guardados en el disco
-
 + Un módulo es un archivo de texto que contiene un programa de Python
-
 + Puede editar los módulos en un entorno de desarrollo, que
   resalta palabras reservadas, realiza identificación automática, etc.
-
 + Guardamos un programa llamado ``caos.py``
-
 + No olvides la extensión ``.py``
-
 + Podemos ejecutar el programa con el botón de ``Run``
 
+
+Construcción del archivo
+========================
+
 + Las líneas que comienzan con **"#"** se llaman comentarios
-
 + Están destinados a ser leídos por humanos y Python los ignora
-
 + Python omite todo el texto desde el **"#"** hasta el final de la línea
-
 
 .. code-block:: python
 
@@ -142,9 +116,7 @@ Python
    # Un programa que ilustra la Teoria del caos
 
 + ``x`` es un ejemplo de una variable
-
 + En ``x`` asignaremos un valor al que se puede hacer referencia más adelante
-
 + Se mostrará el mensaje entre comillas y la respuesta se almacenará en ``x``
 
 .. code-block:: python
@@ -152,9 +124,7 @@ Python
    x = eval(input("Ingrese un número entre 0 y 1:"))
 
 + Hay comandos de bucle o ciclos como el comando ``for``
-
 + Un bucle o ciclo se usa para repetir un bloque de código varias veces
-
 + En este ejemplo, el siguiente bloque se repetirá 10 veces
 
 .. code-block:: python
@@ -162,17 +132,19 @@ Python
    for i in range(10):
 
 + Llamamos **sangría** a los espacios al comienzo de la línea 
-
 + En Python, la sangría delimita el bloque que se ejecutará
-
 + El cálculo ``3.9 * x * (1-x)`` se realizará en la CPU y se asignará a la variable
   ``x``
 
+Resultado
+=========
 
 .. activecode:: ac_l38_1
     :language: python3
     :python3_interpreter: brython
 
+    # Archivo caos.py
+    # Un programa que ilustra la Teoria del caos
     print("Este programa ilustra el comportamiento caótico.")
     x = eval(input("Ingrese un número entre 0 y 1:"))
     for i in range(10):
@@ -186,28 +158,42 @@ Python
 Ejercicio
 =========
 
-+ Cambie el programa anterior para que pueda ingresar un valor e ingresar
-  correr por n veces en lugar del valor 10
++ Cambie el programa anterior para que pueda ingresar un valor e ingresar correr por 
+  n veces en lugar del valor 10. Asigne ese valor a una variable llamada ``n``.
++ **Debe llamar su variable n para que su programa pase la prueba, de lo contrario dará error.**
 
 .. activecode:: ac_l38_2
     :language: python3
     :python3_interpreter: brython
 
+    # Archivo caos.py
+    # Un programa que ilustra la Teoria del caos
     print("Este programa ilustra el comportamiento caótico.")
     x = eval(input("Ingrese un número entre 0 y 1:"))
     for i in range(10):
         x = 3.9 * x * (1 - x)
         print("%2.3f" % x)
+    
+    ====
+    import unittest
+
+    class myTests(unittest.TestCase):
+
+        def testOne(self):
+
+            self.assertEqual(n, i+1, "El número de ciclos no es el especificado por el usuario")
+
+    myTests().testOne()
+    print("-------------------------------------")
+    print("Haz aprobado el 100% de las pruebas.")
 
 Resumen
 =======
 
 + La descripción de una secuencia de pasos para resolver un problema se llama
   algoritmo computacional.
-
 + Los algoritmos son programas (software) que determinan que hará
   la computadora (hardware).
-
 + El proceso de creación de software se llama programación.
 
 
@@ -215,11 +201,8 @@ Recuerde
 ========
 
 + Los lenguajes de programación tienen una sintaxis formal
-
 + Las computadoras solo entienden el lenguaje de máquina
-
 + Python es un lenguaje interpretado de alto nivel
-
 + El intérprete de Python convierte los comandos instrucción por instrucción
   a lenguaje máquina
 

--- a/_sources/lectures/TWP38.rst
+++ b/_sources/lectures/TWP38.rst
@@ -185,7 +185,7 @@ Ejercicio
 
     myTests().testOne()
     print("-------------------------------------")
-    print("Haz aprobado el 100% de las pruebas.")
+    print("Has aprobado el 100% de las pruebas.")
 
 Resumen
 =======


### PR DESCRIPTION
## Summary

This PR partially closes https://github.com/angelasofiaremolinagutierrez/PyZombis/issues/15
Fixed:
1. Repeated titles (slides titles) are removed (all lectures from TWP05 to TWP38). 
2. An image of a table was replaced by a rst table on lecture TWP15.
3. Small bug left on #127 with TWP05 backticks (``) problem
4. Code screenshots were replaced by code-blocks or activecode blocks in TWP33 and TWP38.
5. A unit test was implemented for exercise on lecture TWP38. **Please note: that last test could not be done with library `TestCaseGui` given that Brython does not support it. I had to use only unittest.**

**Note: This might look like a large PR, but it is mostly because I'm deleting duplicated text. Real important changes are in files: TWP15 (table), TWP33 and TWP38 (replacing code screenshots and unit test).**

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

