### PR TITLE
Change quizzes tests structure

### DIFF
--- a/tests/test_quiz10.py
+++ b/tests/test_quiz10.py
@@ -3,16 +3,14 @@ def test_quiz10_11_good(page):
     page.goto("quiz/Quiz10.html")
     page.wait_for_load_state()
 
+    # Do the exercise
     page.click("text=def tiene_2(numeros):")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type("return '2, 2' in str(numeros)")
 
-    page.press("text=def tiene_2(numeros):", "ArrowDown")
-    page.press("text=def tiene_2(numeros):", "Tab")
-
-    page.type("text=def tiene_2(numeros):", "return '2, 2' in str(numeros)")
-
+    # Run the exercise and check it passed all tests
     page.click("#q10_11 >> *css=button >> text=Run")
 
     page.hover("#q10_11 >> text=You passed:")
-    page.press("text=def tiene_2(numeros):", "ArrowDown")
-
     assert page.inner_text("#q10_11 >> text=You passed:") == "You passed: 100.0% of the tests"

--- a/tests/test_quiz11.py
+++ b/tests/test_quiz11.py
@@ -4,18 +4,12 @@ def test_quiz11_3(page):
 
     # Do the exercise
     page.click("text=def remplazar_primer_caracter(s):")
-    page.press("text=def remplazar_primer_caracter(s):", "ArrowDown")
-    page.press("text=def remplazar_primer_caracter(s):", "Tab")
-    page.type(
-        "text=def remplazar_primer_caracter(s):",
-        "return s[0] + s[1:].replace(s[0], '*')",
-    )
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type("return s[0] + s[1:].replace(s[0], '*')")
 
     # Run the exercise and check it passed all tests
     page.click("#q11_3 >> *css=button >> text=Run")
 
     page.hover("#q11_3 >> text=You passed:")
-    assert (
-        page.inner_text("#q11_3 >> text=You passed:")
-        == "You passed: 100.0% of the tests"
-    )
+    assert page.inner_text("#q11_3 >> text=You passed:") == "You passed: 100.0% of the tests"

--- a/tests/test_quiz12.py
+++ b/tests/test_quiz12.py
@@ -3,33 +3,26 @@ def test_quiz12_1(page):
     page.goto("quiz/Quiz12.html")
     page.wait_for_load_state()
 
+    # Do the exercise
     page.click("text=def verbo(s):")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
 
-    page.press("text=verbo(s):", "ArrowDown")
-    page.press("text=verbo(s):", "Tab")
+    # Code to type
+    ins = ["if len(s) >= 3:", "if s[-3:] != 'ing':", "s = s + 'ing'", "else:", "s = s + 'ly'"]
+    for i in ins[:3]:
+        page.keyboard.type(i)
+        page.keyboard.press("Enter")
+    for i in range(4):
+        page.keyboard.press("Backspace")
+    for i in ins[3:]:
+        page.keyboard.type(i)
+        page.keyboard.press("Enter")
+    for i in range(8):
+        page.keyboard.press("Backspace")
+    page.keyboard.type("return s")
 
-    page.type("text=verbo(s):", "if len(s) >= 3:")
-    page.press("text=verbo(s):", "Enter")
-
-    page.type("text=verbo(s):", "if s[-3:] != 'ing':")
-    page.press("text=verbo(s):", "Enter")
-
-    page.type("text=verbo(s):", "s = s + 'ing'")
-    page.press("text=verbo(s):", "Enter")
-    page.press("text=verbo(s):", "ArrowDown")
-    page.press("text=verbo(s):", "Tab")
-    page.press("text=verbo(s):", "Tab")
-
-    page.type("text=verbo(s):", "else:")
-    page.press("text=verbo(s):", "Enter")
-
-    page.type("text=verbo(s):", "s = s + 'ly'")
-    page.press("text=verbo(s):", "Enter")
-    page.press("text=verbo(s):", "ArrowDown")
-    page.press("text=verbo(s):", "Tab")
-
-    page.type("text=verbo(s):", "return s")
-
+    # Run the exercise and check it passed all unit tests
     page.click("#q12_1 >> *css=button >> text=Run")
 
     page.hover("#q12_1 >> text=You passed:")

--- a/tests/test_quiz13.py
+++ b/tests/test_quiz13.py
@@ -4,10 +4,9 @@ def test_quiz13_1(page):
 
     # Do the exercise
     page.click("text=def terminan_igual(palabras):")
-    page.press("text=def terminan_igual(palabras):", "ArrowDown")
-    page.press("text=def terminan_igual(palabras):", "Tab")
-    page.type(
-        "text=def terminan_igual(palabras):",
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type(
         "return len([palabra for palabra in palabras if len(palabra) >= 2 and palabra[0] == palabra[-1]])",
     )
 

--- a/tests/test_quiz14.py
+++ b/tests/test_quiz14.py
@@ -3,13 +3,13 @@ def test_quiz14_1(page):
     page.goto("quiz/Quiz14.html")
     page.wait_for_load_state()
 
+    # Do the exercise
     page.click("text=def remover_iguales(numeros):")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type("return sorted(list(set(numeros)))")
 
-    page.press("text=remover_iguales(numeros):", "ArrowDown")
-    page.press("text=remover_iguales(numeros):", "Tab")
-
-    page.type("text=remover_iguales(numeros):", "return sorted(list(set(numeros)))")
-
+    # Run the exercise and check it passed all unit tests
     page.click("#q14_1 >> *css=button >> text=Run")
 
     page.hover("#q14_1 >> text=You passed:")

--- a/tests/test_quiz2.py
+++ b/tests/test_quiz2.py
@@ -1,14 +1,13 @@
 def test_quiz2_2(page):
     page.goto("quiz/Quiz2.html")
 
+    # Do the exercise
     page.click("text=def es_bisiesto(anio):")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type("return anio % 4 == 0 and (anio % 100 != 0 or anio % 400 == 0)")
 
-    page.press("text=def es_bisiesto(anio):", "ArrowDown")
-
-    page.press("text=def es_bisiesto(anio):", "Tab")
-
-    page.type("text=def es_bisiesto(anio):", "return anio % 4 == 0 and (anio % 100 != 0 or anio % 400 == 0)")
-
+    # Run the exercise and check it passed all unit tests
     page.click("#q2_2 >> *css=button >> text=Run")
 
     page.hover("#q2_2 >> text=You passed:")

--- a/tests/test_quiz3.py
+++ b/tests/test_quiz3.py
@@ -4,8 +4,8 @@ def test_quiz3_2(page):
 
     # Do the exercise
     page.click("text=def calcular_cambio(cobro, pago):")
-    page.press("text=def calcular_cambio(cobro, pago):", "ArrowDown")
-    page.press("text=def calcular_cambio(cobro, pago):", "Tab")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
 
     instructions = [
         "cambio = pago - cobro",
@@ -16,13 +16,13 @@ def test_quiz3_2(page):
     ]
 
     for inst in instructions:
-        page.type("text=def calcular_cambio(cobro, pago):", inst)
-        page.press("text=def calcular_cambio(cobro, pago):", "Enter")
+        page.keyboard.type(inst)
+        page.keyboard.press("Enter")
 
     for i in range(4):
-        page.press("text=def calcular_cambio(cobro, pago):", "Backspace")
+        page.keyboard.press("Backspace")
 
-    page.type("text=def calcular_cambio(cobro, pago):", "return billetes")
+    page.keyboard.type("return billetes")
 
     # Click #ejercicio-2 >> text=Run
     page.click("#ejercicio-2 >> text=Run")

--- a/tests/test_quiz4.py
+++ b/tests/test_quiz4.py
@@ -4,9 +4,9 @@ def test_quiz4_1(page):
 
     # Do the exercise
     page.click("text=def valores_extremos(numeros):")
-    page.press("text=def valores_extremos(numeros):", "ArrowDown")
-    page.press("text=def valores_extremos(numeros):", "Tab")
-    page.type("text=def valores_extremos(numeros):", "return (max(numeros), min(numeros))")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type("return (max(numeros), min(numeros))")
 
     # Run the exercise and check it passed all tests
     page.click("#q4_1 >> *css=button >> text=Run")

--- a/tests/test_quiz5.py
+++ b/tests/test_quiz5.py
@@ -5,10 +5,10 @@ def test_quiz5_10(page):
 
     page.click("text=def es_numero_ponteironuloville(numero):")
 
-    page.press("text=es_numero_ponteironuloville(numero):", "ArrowDown")
-    page.press("text=es_numero_ponteironuloville(numero):", "Tab")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
 
-    page.type("text=es_numero_ponteironuloville(numero):", "return True")
+    page.keyboard.type("return True")
 
     page.click("#q5_10 >> *css=button >> text=Run")
 

--- a/tests/test_quiz6.py
+++ b/tests/test_quiz6.py
@@ -1,22 +1,19 @@
-# Testing ex 1
-
 def test_quiz6_1(page):
     # Go to http://localhost:8000/quiz/Quiz6.html
     page.goto("quiz/Quiz6.html")
-    
+
     page.click("text=def dormir(dia_semana, dia_festivo):")
-    page.press("text=def dormir(dia_semana, dia_festivo):", "ArrowDown")
-    page.press("text=def dormir(dia_semana, dia_festivo):", "Tab")
-    
-    page.type("text=def dormir(dia_semana, dia_festivo):", "if not dia_semana or dia_festivo:")
-    page.press("text=def dormir(dia_semana, dia_festivo):", "Enter")
-    page.type("text=def dormir(dia_semana, dia_festivo):", "return True") 
-    page.press("text=def dormir(dia_semana, dia_festivo):", "Enter")
-    page.type("text=def dormir(dia_semana, dia_festivo):", "return False")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+
+    page.keyboard.type("if not dia_semana or dia_festivo:")
+    page.keyboard.press("Enter")
+    page.keyboard.type("return True")
+    page.keyboard.press("Enter")
+    page.keyboard.type("return False")
 
     # Run an check it passed all unit tests
     page.click("#q6_1 >> *css=button >> text=Run")
 
     page.hover("#q6_1 >> text=You passed:")
     assert page.inner_text("#q6_1 >> text=You passed:") == "You passed: 100.0% of the tests"
-    

--- a/tests/test_quiz7.py
+++ b/tests/test_quiz7.py
@@ -5,18 +5,15 @@ def test_quiz7_1_good(page):
 
     page.click("text=def multi_cadena(s, n):")
 
-    page.press("text=def multi_cadena(s, n):", "ArrowDown")
-    page.press("text=def multi_cadena(s, n):", "Tab")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
 
-    page.type("text=def multi_cadena(s, n):", "return s * n")
+    page.keyboard.type("return s * n")
 
     page.click("#q7_1 >> *css=button >> text=Run")
 
     page.hover("#q7_1 >> text=You passed:")
-    assert (
-        page.inner_text("#q7_1 >> text=You passed:")
-        == "You passed: 100.0% of the tests"
-    )
+    assert page.inner_text("#q7_1 >> text=You passed:") == "You passed: 100.0% of the tests"
 
 
 def test_quiz7_1_bad(page):
@@ -26,14 +23,12 @@ def test_quiz7_1_bad(page):
 
     page.click("text=def multi_cadena(s, n):")
 
-    page.press("text=def multi_cadena(s, n):", "ArrowDown")
-    page.press("text=def multi_cadena(s, n):", "Tab")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
 
-    page.type("text=def multi_cadena(s, n):", "return 5")
+    page.keyboard.type("return 5")
 
     page.click("#q7_1 >> *css=button >> text=Run")
 
     page.hover("#q7_1 >> text=You passed:")
-    assert (
-        page.inner_text("#q7_1 >> text=You passed:") == "You passed: 0.0% of the tests"
-    )
+    assert page.inner_text("#q7_1 >> text=You passed:") == "You passed: 0.0% of the tests"

--- a/tests/test_quiz9.py
+++ b/tests/test_quiz9.py
@@ -4,9 +4,9 @@ def test_quiz9_1(page):
 
     # Complete the exercise
     page.click("text=def primer_o_ultimo_6(numeros):")
-    page.press("text=def primer_o_ultimo_6(numeros):", "ArrowDown")
-    page.press("text=def primer_o_ultimo_6(numeros):", "Tab")
-    page.type("text=def primer_o_ultimo_6(numeros):", "return 6 == numeros[0] or 6 == numeros[-1]")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type("return 6 == numeros[0] or 6 == numeros[-1]")
 
     # Click button:has-text("Run")
     page.click("#q9_1 >> *css=button >> text=Run")
@@ -14,4 +14,3 @@ def test_quiz9_1(page):
     # Test it passed all unit tests
     page.hover("#q9_1 >> text=You passed:")
     assert page.inner_text("#q9_1 >> text=You passed:") == "You passed: 100.0% of the tests"
-    

--- a/tests/test_quizExtra.py
+++ b/tests/test_quizExtra.py
@@ -4,17 +4,17 @@ def test_quizExtra_4(page):
 
     # Do the exercise
     page.click("text=def suma_granos(n):")
-    page.press("text=def suma_granos(n):", "ArrowDown")
-    page.press("text=def suma_granos(n):", "Tab")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
 
+    # Code to type
     instructions = ["suma = 0", "for n in range(1, 65):", "m = int(pow(2, n - 1))", "suma = suma + m"]
     for inst in instructions:
-        page.type("text=def suma_granos(n):", inst)
-        page.press("text=def suma_granos(n):", "Enter")
-
+        page.keyboard.type(inst)
+        page.keyboard.press("Enter")
     for i in range(4):
-        page.press("text=def suma_granos(n):", "Backspace")
-    page.type("text=def suma_granos(n):", "return suma")
+        page.keyboard.press("Backspace")
+    page.keyboard.type("return suma")
 
     # Click button:has-text("Run")
     page.click("#qExtra_4 >> *css=button >> text=Run")

--- a/tests/test_quizExtra2.py
+++ b/tests/test_quizExtra2.py
@@ -4,9 +4,9 @@ def test_quizExtra2_3_bad(page):
 
     # Complete the exercise
     page.click("text=def calcular_pi(n):")
-    page.press("text=def calcular_pi(n):", "ArrowDown")
-    page.press("text=def calcular_pi(n):", "Tab")
-    page.type("text=def calcular_pi(n):", "return 2")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Tab")
+    page.keyboard.type("return 2")
 
     # Click button:has-text("Run")
     page.click("#qExtra2_3 >> *css=button >> text=Run")


### PR DESCRIPTION
## Summary

This PR closes LeoCumpli21/PyZombis#52. These are small changes. The idea of  avoiding the selector in the `press` and `type` methods with the keyboard class is that, if for whatever reason that selector is changed, in the tests the only thing that would need a change as well would be the command `page.click`.

**Note:**
The biggest change is in `test_quiz12.py` file. Here, the instructions are now typed within a for loop. 

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

