### PR TITLE
Add numbered and remove disqus tags

### DIFF
--- a/_sources/lectures/TWP05/toctree.rst
+++ b/_sources/lectures/TWP05/toctree.rst
@@ -13,6 +13,7 @@ Variables y entrada de datos
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP05_1.rst
    TWP05_2.rst

--- a/_sources/lectures/TWP10/TWP10_3.rst
+++ b/_sources/lectures/TWP10/TWP10_3.rst
@@ -1,5 +1,5 @@
-if
-==
+``if``
+======
 
 + Lea dos valores enteros e imprima el más grande
 

--- a/_sources/lectures/TWP10/TWP10_4.rst
+++ b/_sources/lectures/TWP10/TWP10_4.rst
@@ -1,5 +1,5 @@
-if / else
-=========
+``if`` / ``else``
+=================
 
 + ¿Qué hacer cuando la condición ``if`` es falsa?.
 + La clausula ``else`` significa en caso contrario.

--- a/_sources/lectures/TWP10/TWP10_6.rst
+++ b/_sources/lectures/TWP10/TWP10_6.rst
@@ -1,5 +1,5 @@
-elif
-====
+``elif``
+========
 
 + La cláusula elif sustituye a ``else`` y ``if``.
 

--- a/_sources/lectures/TWP10/toctree.rst
+++ b/_sources/lectures/TWP10/toctree.rst
@@ -13,6 +13,7 @@ Condiciones
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP10_1.rst
    TWP10_2.rst

--- a/_sources/lectures/TWP15/toctree.rst
+++ b/_sources/lectures/TWP15/toctree.rst
@@ -13,6 +13,7 @@ Repeticiones
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP15_1.rst
    TWP15_2.rst

--- a/_sources/lectures/TWP17/toctree.rst
+++ b/_sources/lectures/TWP17/toctree.rst
@@ -13,6 +13,7 @@ Listas
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP17_1.rst
    TWP17_2.rst

--- a/_sources/lectures/TWP18/toctree.rst
+++ b/_sources/lectures/TWP18/toctree.rst
@@ -13,6 +13,7 @@ Strings
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP18_1.rst
    TWP18_2.rst

--- a/_sources/lectures/TWP20/toctree.rst
+++ b/_sources/lectures/TWP20/toctree.rst
@@ -13,6 +13,7 @@ for, random y funciones
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP20_1.rst
    TWP20_2.rst

--- a/_sources/lectures/TWP23/toctree.rst
+++ b/_sources/lectures/TWP23/toctree.rst
@@ -13,6 +13,7 @@ Archivos y diccionarios
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP23_1.rst
    TWP23_2.rst

--- a/_sources/lectures/TWP25/toctree.rst
+++ b/_sources/lectures/TWP25/toctree.rst
@@ -13,6 +13,7 @@ Clases y objetos
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP25_1.rst
    TWP25_2.rst

--- a/_sources/lectures/TWP30/toctree.rst
+++ b/_sources/lectures/TWP30/toctree.rst
@@ -13,6 +13,7 @@ Revisión general 1
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP30_1.rst
    TWP30_2.rst

--- a/_sources/lectures/TWP33/toctree.rst
+++ b/_sources/lectures/TWP33/toctree.rst
@@ -19,6 +19,7 @@ Revisión de String
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP33_1.rst
    TWP33_2.rst

--- a/_sources/lectures/TWP35/TWP35_4.rst
+++ b/_sources/lectures/TWP35/TWP35_4.rst
@@ -30,8 +30,3 @@ JSON
     texto = urllib.request.urlopen(url).read()
     data = json.loads(texto)
     print(data["value"]["joke"])
-
-
-.. disqus::
-   :shortname: pyzombis
-   :identifier: lecture11

--- a/_sources/lectures/TWP35/toctree.rst
+++ b/_sources/lectures/TWP35/toctree.rst
@@ -13,6 +13,7 @@ Revisión de Funciones
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP35_1.rst
    TWP35_2.rst

--- a/_sources/lectures/TWP37/toctree.rst
+++ b/_sources/lectures/TWP37/toctree.rst
@@ -13,6 +13,7 @@ Revisión de Archivos, Listas y Diccionarios
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP37_1.rst
    TWP37_2.rst

--- a/_sources/lectures/TWP38/TWP38_4.rst
+++ b/_sources/lectures/TWP38/TWP38_4.rst
@@ -48,8 +48,3 @@ Recuerde
 + Python es un lenguaje interpretado de alto nivel
 + El intérprete de Python convierte los comandos instrucción por instrucción
   a lenguaje máquina
-
-
-.. disqus::
-    :shortname: pyzombis
-    :identifier: lecture13

--- a/_sources/lectures/TWP38/toctree.rst
+++ b/_sources/lectures/TWP38/toctree.rst
@@ -13,6 +13,7 @@ Revisión general 2
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP38_1.rst
    TWP38_2.rst

--- a/_sources/lectures/TWP40/toctree.rst
+++ b/_sources/lectures/TWP40/toctree.rst
@@ -13,6 +13,7 @@ Revisión general 3
 .. toctree::
    :caption: Contenido
    :maxdepth: 1
+   :numbered:
 
    TWP40_1.rst
    TWP40_2.rst


### PR DESCRIPTION
## Summary

This PR closes angelasofiaremolinagutierrez/PyZombis#20

- `:numbered:` tag was added to all sub lectures toctrees.
- `.. disqus:`: tag was removed from all lectures.
- Formatting code for titles in lecture `TWP10: Condiciones`

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots

![image](https://user-images.githubusercontent.com/10239480/129493503-5b36142a-be83-4864-adf2-ec91abadab62.png)
