### PR TITLE
Fix build: branch rename master to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::set-output name=REPO::$(< /tmp/website-output/REPO)"
       - name: Get PR ref
         id: get_pull_request_ref
-        if: steps.get_ticket.outputs.NR  != 'master'
+        if: steps.get_ticket.outputs.NR  != 'main'
         uses: octokit/request-action@v2.x
         with:
           route: GET /repos/:repository/pulls/:issue_id
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Create Deployment
         id: create_deployment
-        if: steps.get_ticket.outputs.NR != 'master' && steps.get_ticket.outputs.REPO == github.repository
+        if: steps.get_ticket.outputs.NR != 'main' && steps.get_ticket.outputs.REPO == github.repository
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/:repository/deployments
@@ -87,7 +87,7 @@ jobs:
           cp -rfv /tmp/website-output/* gh-pages/$NR/
       - name: Start Deployment (in progress)
         id: start_deployment
-        if: steps.get_ticket.outputs.NR != 'master' && steps.get_ticket.outputs.REPO == github.repository
+        if: steps.get_ticket.outputs.NR != 'main' && steps.get_ticket.outputs.REPO == github.repository
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/:repository/deployments/:deployment/statuses
@@ -107,14 +107,14 @@ jobs:
             publish_branch: gh-pages
             github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Comment on PR'
-        if: github.ref != 'master'
+        if: github.ref != 'main'
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var fs = require('fs');
             var issue_number = Number(fs.readFileSync('/tmp/website-output/NR'));
-            // if this is not a PR (merge to master build), do not comment:
+            // if this is not a PR (merge to main build), do not comment:
             if (issue_number > 0) {
               await github.issues.createComment({
                 owner: context.repo.owner,
@@ -125,7 +125,7 @@ jobs:
             }
       - name: Deployment success
         id: successful_deployment
-        if: steps.get_ticket.outputs.NR != 'master' && steps.get_ticket.outputs.REPO == github.repository
+        if: steps.get_ticket.outputs.NR != 'main' && steps.get_ticket.outputs.REPO == github.repository
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/:repository/deployments/:deployment/statuses
@@ -141,7 +141,7 @@ jobs:
 
       - name: Deployment failure
         id: failed_deployment
-        if: failure() && steps.get_ticket.outputs.NR != 'master' && steps.get_ticket.outputs.REPO == github.repository
+        if: failure() && steps.get_ticket.outputs.NR != 'main' && steps.get_ticket.outputs.REPO == github.repository
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/:repository/deployments/:deployment/statuses

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Build PR
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -37,14 +37,14 @@ jobs:
       run: |
         runestone build
     - name: Save PR number
-      if: github.ref != 'refs/heads/master'
+      if: github.ref != 'refs/heads/main'
       run: |
         echo ${{ github.event.number }} > ./build/PyZombis/NR
         echo ${{ github.event.pull_request.head.repo.full_name }} > ./build/PyZombis/REPO
     - name: Save branch name
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/main'
       run: |
-        echo "master" > ./build/PyZombis/NR
+        echo "main" > ./build/PyZombis/NR
     - name: Upload generated content artifact
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
## Summary

Fix GitHub Workflow and GitHub pages hard-coded branch names

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots

(prefer Playwright recorded video or animated gif)
