### PR TITLE
added external api to replace failing api

### DIFF
--- a/_sources/challenges/Reto01.rst
+++ b/_sources/challenges/Reto01.rst
@@ -132,15 +132,16 @@ Este reto consiste en crear el juego de **ahorcado** a partir de código Python.
             import json
             from random import choice
 
-            api_url = "http://universities.hipolabs.com/search"
+            api_url = "https://countriesnow.space/api/v0.1/countries/state/cities"
+            payload = {"country": "spain", "state": "Community of Madrid"}
+            headers = {}
 
-            solicitud = requests.get(api_url)
+            solicitud = requests.request("POST", api_url, headers=headers, data=payload)
             datos = json.loads(solicitud.text)
 
             ciudades = []
-            for universidad in datos:
-                if universidad["country"] not in ciudades:
-                    ciudades.append(universidad["country"].lower().replace(" ", ""))
+            for ciudad in datos['data']:
+                ciudades.append(ciudad)
 
             def escoger(ciudades):
                 # Desarrolle la función


### PR DESCRIPTION
Signed-off-by: Shivam Shandilya <shivam.stpaulsdarjeeling@gmail.com>

## Summary
This PR replaces the failing [University API](https://universities.hipolabs.com/search) with a [working API](https://documenter.getpostman.com/view/1134062/T1LJjU52#intro) that uses https and returns names of cities.

- the cities of a particular country and state can be returned
- this configuration can make the exercise more subjective for the users

This PR thus closes the issue #197 

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Python code
- [x] Reviewers assigned (all peers & at least 1 mentor)


