### PR TITLE
Fixed failing proxy in TWP33 lectures

### DIFF
--- a/_sources/lectures/TWP33/TWP33_1.rst
+++ b/_sources/lectures/TWP33/TWP33_1.rst
@@ -17,7 +17,7 @@ Código Starbuzz actual
    
     from urllib.request import urlopen
 
-    precios = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices.html"
+    precios = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices.html"
     pagina = urlopen(precios)
     texto = pagina.read()
     print(texto)

--- a/_sources/lectures/TWP33/TWP33_3.rst
+++ b/_sources/lectures/TWP33/TWP33_3.rst
@@ -23,7 +23,7 @@ Cortar
    
     from urllib.request import urlopen
 
-    URL_PRECIOS = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices.html"
+    URL_PRECIOS = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices.html"
     pagina = urlopen(URL_PRECIOS)
     texto = pagina.read()
     print(texto[234:238])

--- a/_sources/lectures/TWP33/TWP33_4.rst
+++ b/_sources/lectures/TWP33/TWP33_4.rst
@@ -17,7 +17,7 @@ Programa de fidelización
    
     from urllib.request import urlopen
 
-    URL_PRECIOS_LOYALTY = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices-loyalty.html"
+    URL_PRECIOS_LOYALTY = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices-loyalty.html"
     pagina = urlopen(URL_PRECIOS_LOYALTY)
     texto = pagina.read()
     print(texto[234:238])

--- a/_sources/lectures/TWP33/TWP33_5.rst
+++ b/_sources/lectures/TWP33/TWP33_5.rst
@@ -29,7 +29,7 @@ Método ``find``
 
     from urllib.request import urlopen
 
-    URL_PRECIOS_LOYALTY = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices-loyalty.html"
+    URL_PRECIOS_LOYALTY = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices-loyalty.html"
     pagina = urlopen(URL_PRECIOS_LOYALTY)
     texto = pagina.read()
     ubicacion = texto.find(">$")

--- a/_sources/lectures/TWP33/TWP33_6.rst
+++ b/_sources/lectures/TWP33/TWP33_6.rst
@@ -13,7 +13,7 @@ Solo cuando es inferior a 4,74
    
     from urllib.request import urlopen
 
-    URL_PRECIOS_LOYALTY = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices-loyalty.html"
+    URL_PRECIOS_LOYALTY = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices-loyalty.html"
     pagina = urlopen(URL_PRECIOS_LOYALTY)
     texto = pagina.read()
     ubicacion = texto.find(">$")

--- a/_sources/lectures/TWP33/TWP33_7.rst
+++ b/_sources/lectures/TWP33/TWP33_7.rst
@@ -17,7 +17,7 @@ Convertir a ``float``
    
     from urllib.request import urlopen
 
-    URL_PRECIOS_LOYALTY = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices-loyalty.html"
+    URL_PRECIOS_LOYALTY = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices-loyalty.html"
     pagina = urlopen(URL_PRECIOS_LOYALTY)
     texto = pagina.read()
     ubicacion = texto.find(">$")
@@ -44,7 +44,7 @@ Convertir a ``float``
    
     from urllib.request import urlopen
 
-    URL_PRECIOS_LOYALTY = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices-loyalty.html"
+    URL_PRECIOS_LOYALTY = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices-loyalty.html"
     precio = 99.99
     while precio >= 4.74:
         pagina = urlopen(URL_PRECIOS_LOYALTY)

--- a/_sources/lectures/TWP33/TWP33_9.rst
+++ b/_sources/lectures/TWP33/TWP33_9.rst
@@ -21,7 +21,7 @@ Biblioteca ``time``
     import sys
     sys.setExecutionLimit(180000)
 
-    URL_PRECIOS_LOYALTY = "https://cors.bridged.cc/http://beans.itcarlow.ie/prices-loyalty.html"
+    URL_PRECIOS_LOYALTY = "https://api.allorigins.win/raw?url=http://beans.itcarlow.ie/prices-loyalty.html"
     precio = 99.99
     limite = 0
     disponibilidad = True


### PR DESCRIPTION
Signed-off-by: Shivam Shandilya <shivam.stpaulsdarjeeling@gmail.com>

## Summary
This PR fixes the failing proxy in TWP33 lectures and thus closes #203 .

**7 lectures** under TWP33 used `https://cors.bridged.cc/` proxy, which is now replaced by `https://api.allorigins.win/raw?url=`

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [ ] Test coverage with Playwright implemented; locators are Python code
- [x] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots
![9ea0a8f7-15d5-474a-89b5-16bb756594f7](https://user-images.githubusercontent.com/55462040/158700103-2a63a706-a97d-4884-bd96-d0f05a6c52c8.gif)


