### PR TITLE
Fixed failing proxy in TWP45 lectures

### DIFF
--- a/_sources/lectures/TWP45/TWP45_2.rst
+++ b/_sources/lectures/TWP45/TWP45_2.rst
@@ -17,7 +17,7 @@ En este ejercicio vamos a acceder a Reddit para obetener datos como los de la si
     import json
     
     # La url de Reddit a la que accederemos
-    url = "https://cors.bridged.cc/http://www.reddit.com/r/Python/.json"
+    url = "https://api.allorigins.win/raw?url=http://www.reddit.com/r/Python/.json"
     resp = urllib.request.urlopen(url).read()
     
     # La respuesta se da en formato json, se debe transformar a  

--- a/_sources/lectures/TWP45/TWP45_3.rst
+++ b/_sources/lectures/TWP45/TWP45_3.rst
@@ -25,7 +25,7 @@ La documentación de la API de `TasteDive <https://tastedive.com/read/api>`_.
     import json
 
     api_url = "https://tastedive.com/api/similar"
-    proxy = "https://cors.bridged.cc/"
+    proxy = "https://api.allorigins.win/raw?url="
 
     # Los parámetros que se le pasaran a la url los escribimos dentro de un diccionario
     parametros = {"q": "ariana grande"}
@@ -62,7 +62,7 @@ se transforma a un diccionario de Python. Sin embargo, no es del todo legible. E
     import json
 
     api_url = "https://tastedive.com/api/similar?"
-    proxy = "https://cors.bridged.cc/"
+    proxy = "https://api.allorigins.win/raw?url="
     # La siguiente línea es para los parámetros de la url.
     parametros = urllib.parse.urlencode({"q": "coldplay"})
 
@@ -111,7 +111,7 @@ El siguiente ejercicio viene con calificación automática.
     import json
 
     api_url = "https://tastedive.com/api/similar"
-    proxy = "https://cors.bridged.cc/"
+    proxy = "https://api.allorigins.win/raw?url="
 
     # Agregue los parámetros
     parametros = {}
@@ -144,15 +144,15 @@ El siguiente ejercicio viene con calificación automática.
         def testOne(self):
             self.assertEqual(
                 solicitud_url,
-                "https://cors.bridged.cc/https://tastedive.com/api/similar?q=Coco&limit=5&info=1",
-                "Probando que la url sea: https://cors.bridged.cc/https://tastedive.com/api/similar?q=Coco&limit=5&info=1",
+                "https://api.allorigins.win/raw?url=https://tastedive.com/api/similar?q=Coco&limit=5&info=1",
+                "Probando que la url sea: https://api.allorigins.win/raw?url=https://tastedive.com/api/similar?q=Coco&limit=5&info=1",
             )
             self.assertEqual(resultados, 5, "Probando que resultados esté asignado correctamente.")
             self.assertEqual(len(peliculas_similares), 5, "Probando que peliculas_similares sean: 5")
             self.assertEqual(
                 peliculas_similares,
-                ["Toy Story 3", "Finding Nemo", "Inside Out", "Spirited Away", "Monsters, Inc."],
-                "Esperado: ['Toy Story 3', 'Finding Nemo', 'Inside Out', 'Spirited Away', 'Monsters, Inc.']",
+                ["Toy Story 3", "Finding Nemo", "Inside Out", 'Up', "Monsters, Inc."],
+                "Esperado: ['Toy Story 3', 'Finding Nemo', 'Inside Out', 'Up', 'Monsters, Inc.']",
             )
             self.assertEqual(pixar, 5, "Probando que pixar esté asignado correctamente.")
 

--- a/_sources/lectures/TWP45/TWP45_4.rst
+++ b/_sources/lectures/TWP45/TWP45_4.rst
@@ -16,7 +16,7 @@ contiene  dominios, nombres y países de la mayoría de las universidades del mu
     import urllib.parse
     import json
 
-    api_url = "https://cors.bridged.cc/http://universities.hipolabs.com/search?"
+    api_url = "https://api.allorigins.win/raw?url=http://universities.hipolabs.com/search?"
     parametros = urllib.parse.urlencode({"name": "middle", "country": "turkey"})
 
     solicitud = urllib.request.urlopen(api_url + parametros)
@@ -35,7 +35,7 @@ contiene  dominios, nombres y países de la mayoría de las universidades del mu
     import requests
     import json
 
-    api_url = "https://cors.bridged.cc/http://universities.hipolabs.com/search"
+    api_url = "https://api.allorigins.win/raw?url=http://universities.hipolabs.com/search"
     parametros = {"country": "colombia"}
 
     solicitud = requests.get(api_url, params=parametros)

--- a/tests/cassettes/test_l45_3[chromium].yaml
+++ b/tests/cassettes/test_l45_3[chromium].yaml
@@ -15,67 +15,72 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xZbW8bua7+K0RwD9oCEzdpNu2m95OTtEnTpO3G2e1Z3BwU9IieYa0RvZIm7mTR
-        /35AacaZdLvb08XB/RI4sl4o8eHDh/TvWzNu2KLfeg6/b71yC9l6Dv/3+9YbbGjrOWwdSSlbBWxd
-        dav0fyM3TDqwviIM5Ic5wAEQnuzsPoNpQ55LdFBKs2oj+W103GAkAwt0EUMHC7YNrLyYtiQD8w7e
-        8Sf0ME3zWBzMYmtYAqAz4MnqUWnee7QRjjk40jVlbD2FCRymr8UBOhDPFTu0wIZQl5wTwc9u6bms
-        C+Cohhr2VMa8Y81NOqWU7fHw1HhGBxdi2eEErmpKRj8IcCNcEpQYIoSIPsDUxVpcByfibtHSbQEn
-        SBZO0JfX7c4OGYRD8g5tAYfkPmLDDg49xljA1KJzCD/PUY27JJcWHBD8wmUUX8DUIbxdkGWEi9ZX
-        7bChWvzCrNEbOMOGAry1jYRsZ4jiO1iItbJWp+w+2e4I/bZYA3PpwGFDBi64asnCus6uK0s25CJa
-        20H06MJKvD5FFIg1wbkeKIv0+ZjQFLCuyRPocUTLkL6oya50Uq1PTGV2WtMGLvUpK08Yt4e/6MwC
-        Y01eT/AUW++SK6Kk5Qts2HaAjbgq7W35hl2V7p0W3JAPNJr6IMBcve/ygRN9iFJcSasIC/EwYJRd
-        WLHPPtZ9L+hTwmotlg12cIzd+J53noc1Bgil51WPkAyNZNEFxljTGqbWKMxg4aUB7B0x7+7gd4ZB
-        HLzGeFsMk4u8Q4+zHAdzqtCBoRuysuL+BXATHOw00J7+77Bv2iFIQ4PlPVJLT2u44cBqcbqopLfw
-        FAh9WU/gSJqVBPJwwWWdQMtYljU7KRIyajSwFr/M0bXyLL438S6kCVMUFincRV2uJoRSPE3gPcca
-        EEoJUY37n91n+9ftk53dvSdP9hXLuNOwtSyu2HgoX8CH2D973sGxo+0FV60nmLemoqg46A/XuEdr
-        t88xshO105W8QpuidJLY6mdvlarqGFfh+ePH5CZrXvKKDONEfPVY/3usJnx4qCT2Qc9+pCu7L1au
-        1+tJJ21s57TtpBRZMk1KaR5TMyfz+ASfXv5KH+Xp6TKtfnWsi8ejn/9VwNYlhdbGcJ9rr6SDWcLM
-        3rcodzQ1M68iYuevqLeUhsx3MK8C5ets+yoOboo1e6MhpbzRkIsKTf3izrxAninzeIIF/aasE2U0
-        5Qk83D04OHiUdtYoG/PwPfbWHchwFH+HdAVKXEu62N05GzbPU0eHFbD2HCO5FMM97KfemaiQZ7s5
-        DtZeImWr01K0SkYJj2dSOzjHECiST4dOndFom0V0UdHsKayojHxDtitgY0ufadQE+rNLTF65TRRr
-        BjDKSjccCnCyht1nhT6/JUyEqG4qxVqqNNpETFfAYXt7C+dc1VF5v9g8ivR82wVADZox5xtx2PM9
-        gsGu1BklOTVT06EzSrFN2uJux7RX04aofM+G+qwQa2IPVjq0Ub1vmSYwutWDAOQCNXNLo3RawJU0
-        cIpuGQq44gam1pIr4EzQwVEbsFwWcCwOLrlcWmWc92gtlgSzGtdpYu3gEuMtuTn5Sg19ESJZS3CK
-        3usLnolhzcJBhvkXkr85x9az5oNYol2kG15OEvxe+IY6eMgup5skLrLVXiwBBpihrwjmtBBPffbD
-        WCtlTleeLezuFxqfPz5SXKw8h+GJdIOQ08XK0w1LG3oMwBk38At6R12m4nSigZllt+zgWKoh1r5A
-        j4It0/VLmvsWfQe7O3r8zk4BuzugkAiDrbq+l1cDGHNMZ+yFnPzTNWUxnK0hulLsGzCydgqZQ4tL
-        giOLfpkzZs7oCtAklDjAR2GXQ/oNGTgkjLErNgH4mjCFzftaZMVwItaoCxMOJNYaATZNeO05aPDO
-        yhqTohLnmOC0dTHD8owWC9Velt3du6VrOFpDWaPHMpJXJRAHGkwvyfnpvyNdXEn3IbHKh72/kSnO
-        ytX7f+L0yW9UjTLFePRzAXfJ4SU7o+/5hppvCvLx3EGY7+z9VXZAc0MupdL/sjQ/Hrh8xHw9+d6n
-        zEysG97Wk75G/6H0RG5lMeNwtN2hzOGd8nGKbWVMA5fUObEmZGgMJ30pz/rxkdbLwl7PS/AJiv6p
-        nZOPcOhFlKBeKDnBMZ2QoyR/ppY+oTPk4URaa/KR79laauAYF0IpvykdhVFSkUUqWm7IrzTdpIwB
-        pZW1W3CoB62+gXMxzkIIniq0MLctQURX9dOPxXcFZI1HOZMruhsOQVGhElSRMYGpHeT1GjUY8zGW
-        0LuQlL9GteewDL37tNLQcfJNyDYkiEVc5lD3lPV/E8guJpcDOsTBBXawl3lor4B7AF1LJrJpiYaa
-        DqaprFGrDynEHnlk4GUWe8WI9TI2k8uigBEIslERaIOAk4ZzYksx7omgUeIrMVIlKk0KYFfaNpmT
-        zns7FJCzDdQmMDWGFZOaK1MVOacSm8wrNVc1BS1qJD/wnTZWwzBmXuWszzmGIWwyRNTWLI1KcWb7
-        D7ulTWTRv5z6Jp0BUSLaJKp/fLZ7T0urZLdmrfm4r3IoV296NjuOjFaHMSodWPCt+wPr/Snp9a77
-        MPDQd7Legfz09MmPM5ofrEesNx69x3qvXNBrvG3jtzjvbuamFbH/39TD6irDIXqet/GPjDdMu5C0
-        6isEqHtTJDiWchCNX/QcLnMuM2ThCH2j2qeP8zHr3TFe3qmAC6rgnF5ie9ND6kxCDUciVsUDGkwl
-        65esN7JjfCLHr7Nf08E7odrqge/qzloOMGs4at9Ck7g38JqdKeCc1hxUEahcO2Rr4RRNMpNVyr5G
-        y64q4DVytJ2DY8ZQ6F+Xugz9DV53luACy3Msa4tjauYAgTaFRsMZ2QidtK6Cir3tWfCSbdZOlLLa
-        DcEq5QZeqD6iJjkqpGr0hzPpCpihcRSUyV3Sji834vmYQ9WGmOdG3ynZWEIDSU/XXtqqBsuLJAZD
-        qtXzdyv05GIANB9VJOdmCvskRULrvbQpmALgQn2huNaIV09dsHMUJGqgwwwdvPToSg6lfIdCyUHx
-        4W0bU1m7/7fL2u7y5+ntyU97bvbrKGzHo/fCdrZin7oO0zV234rce5Ph4Rmu0FGg53Dd7u/9sHfd
-        7u08/XH4vF/uzNMIXbfPDvbpuj14ijs6sv+sgFNazVvvnsOMki49qrlmr2kAXmPDS1y2oeYCHuj3
-        6qR+QvLsQYBsivpAbXnwaCOedmEwC77ezBzCMtPEXUyfYocCF9zhLS65uFs9HzgDTmqeW04J70qW
-        bYMwqyVqLL7h1UocXJElbeOkvB21H1PAseKq1VqPHMIvHCLCqbaAXmjJFpGd1uNaUtWSLu1CjfAy
-        yfrUcOIY2jmHmv8gey7bhuGU2WPFGrVdC698agldoGd4gzG0epUrXFKodYCjFPArhnapUF1j1Zb6
-        ylehdVTzMj/+x+t2Z/cHk9el0bdOki2HrYsIs7bCNXqcwH1AfEUxDW59W2m752Fv66NCm507d83O
-        RAZJNOXCvg+vVOJqBDriqp5L62sRU0AqdvNJKYHqSWo4PAzJoMSDGxjManbagRK7tOLp0QSmKYbv
-        hb2WWK13SX5EgRVXYUjJa45lDb+2c5wjPOwf9VGxuZtqLwXfR5mnFpxazq5fkLqdsa6l1VJSKz9n
-        ACE9l8BCZU6tDdK+kL1nU5Ltqd/a93brtsFeM/znMmDw0Ychwr+TUA67f7bLg59++2k57pONR+8R
-        yoW4oN4p4JUrJ99ilPuzR0H8/6cH7gRAlq1DF/cuo6buw4mIadDlRNnBke+0l1bALNINwWEbSmq4
-        6Hv8R6LklsKwgxOez0Nf8TrHC/JwxUmdxnHH2vyJ/Oi7GUNjShWhoXnbF9H0ico2lSLjp/hW12vE
-        JGUfTCrt1wJN7xDIKbS/z7sJXG/NWmupu94C/cA3mClUbRNH29SRUehG1584V4m+8EyJw5YE7/FW
-        1mHJees9oGZlRVdtdHdsLXrQMq3qtvN9UpbFMvHJPbAkqihrqHQ6RgqwknVugYUSkxdzuJQ1W+PJ
-        TeBU1vprRH73/qI9gczJMt1ozVT31gzLMjXIJy77IqAm/fGCIDjCZch0kRyZrSwgv1PP3UvKXbfh
-        hxPlHSX/vq3DcUhoUQQsRvrPA3t4jn88OfrwypV/I7SPTuYVngquXl6MQns8+vlfnz//GwAA//8D
-        AKm19kZ5HAAA
+        H4sIAAAAAAAAAwAAAP//rFltbx03rv4rhHEXsYHxiZ1stk3307GdOC92k7WT5i5uFwGPxDPDWCNO
+        JY1PxkX++wWlmeNxmjZtsF+CeCyJFPXw4UP6151Lbtlh2PkBft157tey8wP83687P2JLOz/AzrEY
+        2alg583Q5Z9buWbSD5s3hJHCtAY4AsKDg8PvYNlSYIMejLRdnyjso+cWE1lYo08YB1iza6ELYntD
+        FlYDvOaPGGCZ17F4uEy9ZYmA3kIgp6byunfoEpxw9KR7TOoDxQUc5V+LB/QggWv26IAtoW45I4K3
+        /iqwaSrgpI5aDmRSObHhNlsxsj//vLSB0cO5OPa4gDcNZafvRbgWNgQGY4KYMERY+tSIH+BU/A06
+        uqngFMnBKQbzc39wQBbhiIJHV8ER+Q/YsoejgClVsHToPcLbFapzF+TzhscEP7FJEipYeoRXa3KM
+        cN6Hup8OVI+f2A0GCy+wpQivXCux+BmThAHW4pxs9FEOH+wPhGFfnIWVDOCxJQvnXPfkYNOUpzOG
+        LfmEzg2QAvrYSdBQJIHUEJypQVnn/58Q2go2DQUCNUd0FfMvGnKdLmo0xGTKo7V9ZKOhrANh2p/+
+        RW/XmBoKaiFQ6oPPT5Ekb19jy24AbMXX+WzH1+zrfO+84ZpCpNnSexFW+vq+GFxoIIx4Q12CtQSY
+        MMo+dhzKG+u55/QxY7URxxYHOMFhfs/bl4cNRogmcDcipEAje3SOKTW0gaWzCjNYB2kBx4dYDbfw
+        e4FRPLzEdFNNi6tywoizkgcrqtGDpWty0vEYAdwmB3tNtH/8czo3nxClpcnzEakm0AauObJ6nC8q
+        ORaBImEwzQKOpe0kUoBzNk0GLaMxDXupMjIatLCRcFWyqwssYXTxNqUJcxZWOd1Fn1xdiEYCLeAd
+        pwYQjMSkzv3P4XePfu4fHBw+fPDgkWIZD1p2jsVX2xcqFwgxjWEvJ3j2tL/mug8Eq97WlBQHo3HN
+        e3Ru/wwTe1E/veEOXc7SRWart8EpVTUpdfGH+/fJLzZ8xR1ZxoWE+r7+dF9deL+rJPZebe/pzuGz
+        nZvNZjFIn/oV7XsxIldMCyPtfWpXZO9/+NDb1lx+vOlM3v38RDfPv376TwU7FxR7l+Jdrn0jA1xm
+        zDz8GuXOlhbmVUQc/CH1/lnKVYR8mWafp+l9UsPBai4pYbTkk2JSf3HrV6TAVAg844F+UbpJMlvy
+        AHYPHz9+vJdP1vSaE/Ad2tYTyHKScAtxRUjaSL7YrZ0tjZelM2MVbAKnRD4n74j3ZfA2KdbZbc3B
+        Jkii4nXeik5ZKAPxhTQezjBGShSy0aW3mmaXCX1SGAeKHZnE1+SGCra+jCVGXaDfu8Tiud+mr1K/
+        VTq65liBlw0cfldp+B1hZkJ9JiPOUa1pJmKHCo76mxs447pJSvjVNigyEu0QATVb5mRvxeNI9AgW
+        B6MrDHl1U+ugt8qtbT7i9sR8VtvHpETPlsZykBriAE4GdElf3zEtYHarexHIR2pXjmZ1tII30sIz
+        9FexgjfcwtI58hW8EPRw3Ec0VxWciIcLNldOqeYdOoeG4LLBTV7YeLjAdEN+RaFWR5/ERM4RPMMQ
+        NIIvaL2G12xrkrzBshbjKNPucynrzrAPrGUhGXTrfN+LRQbjk9DSALvsS9XJGqPcIYgjwAiXGGqC
+        Fa0l0FgEMTXKnMsusIPDR5Wm6fd7ipIucJwCpgfEUjW6QNcsfRwRAS+4hZ8weBoKI2eLFi4d+6sB
+        TqSeMu8zLCn0Cms/pVXoMQxweKDmDw4qODwABUicfNX9o8qaoFkyvCAxFg2QrynrybYmbKeZYMHK
+        xiuAjhxeERw7DFelcJbCrnDNeokjfBD2JcF/JAtHhCkN1TYdXxLmJHrXiHQMp+KsPmhGhaRG88Hl
+        BS8DR03lS9NgFlbiPRM8630qIM3vfYrBsb+NW76Gpw2YBgOaREEFQZpIMUeSS+j/QtV4I8P7zDHv
+        H35DwXhhunf/i8sHv1A9Kxjzr58quK0RT9lbjeeP1H5Vl8/XTvr84OEfFQm01+RzRf0vK/STidln
+        PDhS8V0CLTS7ZXG19KViEE0g8p3DgsPZcUeygtfKzjm3lT8tXNDgxdlYoDFZ+lyljd9nkq/oe7WX
+        4RMV/Uu3opDgKIgoXT1RqoITOiVPWQUtHX1EbynAqfTOFpPv2Dlq4QTXQrnaKTnFWYmRde5dril0
+        Wnxy/QDjZOPXHJtJsm/hXM1rEkKgGh2sXE+Q0Nfj8hMJQwVF6lGp64rulmNUVKgSVWQsYOkmlb1B
+        TcZixhEGH3MDoFkdOF7F8fm04dDvFNpYfMgQS3hVUj1QaQPaSG69uJjQIR7OcYCHhYceVnAHoBsp
+        RLY0aKkdYJm7G/X6iGIakUcWnhbNV81Yr2AzP1kSsAJRcpQDGeJrsuCUmd0AnUTOoVWWpc3IuSZw
+        YhMLwXYBeRKxLdae16zVUHV0jw7IkeqdWEGSXpVyPYkEb6HrvWmGClpqJaAWuRnRpAYTbLRKrnvv
+        B/V0JamBQXpfQ87fWnThWGM5QIdBbX3WhKCLAl5aLoU7s1Ygglap3GCiWlR6VcDeuD4HOEfw1dQZ
+        X26TZwFLa1mzTLVAbo9XZLAtTNlw3VDUbk0KZO6KSUylUnBpPDjFiQgK6NXXIv2MeLv/m9PyIbIe
+        saBoyzYgSUKXu4Xvvzu80yRoL+LsRvXG2L5RaUvVNntOjE4/Y1KCcxB6/xse/10aH8H4fmLWv8jj
+        j+Vf/3jw/SWtHm9mPD7/eofHn/uo13jVp6+x+O3K7Yzl0VeF/lxJKxvCiSgKC8Rn+jb3syWFz6mG
+        M3qK/TWVCiqxgWMRR0NOpi+SYTvAa6HG6dGvm8E5jnDZctJphtb0YOEle1vBETsHz9DqwjPacFSx
+        oLrunFXnvkTHvq7gJXJyg4cTxljpvz7PHkZEvRwcwTmaMzSNwzlTF8Ea8wxozKiagxuZ8IKdSjc9
+        dE8jEHXXNUGXqwSvVSlRK5oHMbenf38hA+yON9ur4BKtpxhhN99tr1ISCrCb77OnUr2mALv5RnvF
+        1ROOtcrj3XKzvXIsrtdkEqgad7zOojE2Jdz6bcx32NUrj5OF6bJ7gPaDnlgmMhyykIl9CNJn4EbA
+        tYp2xZBmlzLbOXtPUZImFVyih6cBveFoZFEAUWYkmSPnOPPgMJFm5uPxVC+JTWb3Bn1Nmm5F4mJf
+        N4nCvThGEx2nYbpYrZVdnKUwG9KNlrO0LrLNkoNjDC35e8ohLbUr9VM5LCf5+DSFPQN1fSiDBi0O
+        faRbCezaBZz0Qf0s2iXl0cL0yxavFCRGvHbfZKGLg2nESc0xMwhIsGUkhaZhuqYytVJvjekDmmG0
+        peQsIQUcClXlasHeLuCkTG1yUyx+HlWHMY1OZ/RpABAabTOyGq/GCSZ2XZCPOZvHgcmcAsvw47YT
+        y/Bfo6q02yuD5fWaTZ+7sHkhKLVqfMO/oHHLNd6/6lOejzz65vnIcPF2eXP6r4f+8t8zmpx/vUOT
+        b7uv0ePbbittH387Lf5Wls515O/y3xMLy+j1gONGOxLpNI1fu75t9eMLCRY9/Ig1crFx99Qv0Rdp
+        trgBNmxlQ0HzwsHTQDosvIrkYTdb3Jt0paWQqenJx85JoAAXfYzkHOxms3uF8msp1PhBeu0lMx1I
+        n5opYnewv+7dWukaFVFtaVMxFU9atDQNaTNHbJTHnrjc6X8mJFNDA7RESYs6uiwOrWzlaV/D7hSL
+        kTXJG+nz6AGhZvQJVtqGlg0v6Zp9NU2sV6THNbp6O8ylKQbHDQZtqc97n25gd3yQvcUkgXTIzcmR
+        hWfkuNd2+Td8mAcnfXLsKeesAk0Hrwd/h9VEZeXvGVzAQNFgt6XezO+bhvwoqkbRLMAhcNJBZb2A
+        Z4UFyNE1+XFMM85XQ8qcFDslkiLwLA6ZpH4iTzc9OYQ6j9DV5jTTzeeVIXfu0wrILEWufZyYaqZK
+        M6UaVAyoqi4NWkyD4xuymSnZkmrZobxQySfZ7mxQG6Ca7Ni4KV0Wf9BxTGy0i0nNdsSXb3cvzie8
+        KoRJBx+R/ChoH55oyFtMf16+ve2UmQ4efzMzPXv35N37X96cXT55MmOm+dc7zHQuPmoEK3juzeJr
+        LHV3Neze+VlCJ0FJam9LZYd/RGVt2ZwbMTv8Nya7paea/tJwy295NHYqYlv0RcMNcBwGHftWcJm0
+        QB710VDL1fh3qGNZ9cHnJnKAU16t4jiO8Z7XFOAN50YjzRua32HlrcQYZ6gq7i2t+rH40UcyfW7m
+        5nf/2oD2y6SrY7MxqnG8yOsF/Lxz2TtHw887oP/hay3OKtVYN9E+DVp0MSQ/mlppm7UOrF3JOV8R
+        vMMb2cQrzqSlbTG1nRPdtm2eUu8wgE4P6mG/3CRzCJpcqu8CJ0+qTQO1rsdEEbpcJFYDRE3izIit
+        gqZhZwP5BTyTjf6xrIR8Qk7uo2BFTjXO2JoWYijbsq9JPrIZWznlMQTHKTkaTWR9HT3hVR6ilRnh
+        6HaV1V+eD6+mKSBZaPRvVOPMkdO9wodaRf58mk/x+NuD4/fPvfmGPD8+XdX4TLB7ej7L8/nXT//5
+        9On/AQAA//8DAJSz7NIYHwAA
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 67723118df2c0c23-DFW
+      - 6ed135d8f87e4d7b-SIN
       Connection:
       - keep-alive
       Content-Encoding:
@@ -83,25 +88,138 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 30 Jul 2021 22:58:27 GMT
+      - Wed, 16 Mar 2022 23:18:51 GMT
       Expect-CT:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       NEL:
-      - '{"report_to":"cf-nel","max_age":604800}'
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=DOg4nNAu%2Fiu%2Ban7bDEVbWUtAaWoNIx47k2M6X4SOkhH8Kcvi7%2BZ%2FN%2Bv5Fno6pViNfu7hwVS%2FOkpAi%2BOLEdGBmz7LqljkT%2F2azOkMAxcsgAkzFw7h%2Bvyl8HRWl83A002B"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=xv0%2BhW3bp7%2BwassZ%2BLtC9195t9nZ5midR%2FMfDj%2BV%2F1fT5O%2F082LrwYDX3IcoCoz05k5Wg5hRG9xMWTAInZO%2FiIZI1dgdHggeUPPAdBoyr6GlMPdAIRzb8T4cH1mjMbBP"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Set-Cookie:
-      - tk_s=.eJyrVsrJT04syczPU7KqVkrOLKmMz0vMTVWyUopKLMgvSMxT0lFKzi_NKymqjE_OTwFJ-EYgiUEV-6ZWZCbnA8WLS5NSMssyi4EGxhvCZL0SczKLgdK1tQCMBicW.E-YVkw.zBr5-FLnnrHSV3b0oZK7V256L0c;
-        Domain=.tastedive.com; HttpOnly; Path=/
+      - tk_s=.eJyrVsrJT04syczPU7KqVkrOLKmMz0vMTVWyUvLOz8lOLElU0lFKzi_NKymqjE_OTwFJePohiUEVe-alZIKUFpcmpWSWZRYDzYs3hEmGpxaXKDil5qUn5ijV1gIA8lInvQ.FRQB2w.pESq3gbDEuqOBs7B2SiQ0Y6pEAU;
+        Domain=.tastedive.com; Secure; HttpOnly; Path=/
+      Strict-Transport-Security:
+      - max-age=31536000;
       Transfer-Encoding:
       - chunked
       Vary:
       - Cookie
       alt-svc:
-      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
-        ma=86400
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://tastedive.com/api/similar?q=Coco&limit=5&info=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6xXbW/cyA3+K4RRIAkgr9+QS5N+WseJE8dOAts5F+gVAXeGKzE7GupmRqvIwf33
+        gjOr9Sa43rVFvxheiUNyyOd5SH3bu+GWHYa9F/Bt761fyt4L+Me3vffY0t4L2HspRvYq2Lsdu/y7
+        lTWTPhhuCSOFyQY4AsLx4dEzmLcU2KAHI23XJwr76LnFRBaW6BPGEZbsWuiC2N6QhcUIH/krBphn
+        OxYPN6m3LBHQWwjkNFS2u0OX4IyjJz1jUh8ozuA0vxYP6EEC1+zRAVtCPXJJBJ/8KrBpKuCkiVoO
+        ZFLx2HCboxjZ3308t4HRw5U49jiD24Zy0o8irIUNgcGYICYMEeY+NeJHOBd/j47uKzhHcnCOwfzS
+        Hx6SRTil4NFVcEr+C7bs4TRgShXMHXqP8GmBmtw1+XzgOcHPbJKECuYe4cOSHCNc9aHuJ4ea8Ss7
+        YLBwgS1F+OBaiSXPmCSMsBTnZNCmHB3vj4RhX5yFhYzgsSULV1z35GBoSuuMYUs+oXMjpIA+dhK0
+        FEkgNQSXGlCW+f8zQlvB0FAg0HBEq5hfNOQ6NWq0xGRK09o+stFS1oEw7U9/0dslpoaCRgiU+uBz
+        K5Lk40ts2Y2Arfg6+3a8Zl/ne+cDawqRdkwfRVho930JONNCGPGGugRLCTBhlH3sOJQeq98r+pqx
+        2ohjiyOc4bh7z4fOw4ARogncbRBSoJEzusKUGhpg7qzCDJZBWsBNIxbjA/wuMIqHd5juq8m4Kh42
+        OCs8WFCNHiytyUnHmwrglhzslWg//W3ymz1EaWnKfINUE2iANUfWjPNFJdciUCQMppnBS2k7iRTg
+        ik2TQctoTMNeqoyMBi0MElaFXV1gCZsUHyhNmFlYZbqLtlxTiEYCzeCOUwMIRmLS5P5y9OzpL/3x
+        4dHJ8fFTxTIetuwci6+2HSoXCDFtyl48ePa0v+S6DwSL3taUFAeb4Mp7dG7/EhN70Ty94Q5dZuks
+        q9Wn4FSqmpS6+OLggPxs4BV3ZBlnEuoD/XWgKXx+rCL2WWM/0ZPjDyeHYZiN0qd+QftejMiKaWak
+        PaB2Qfbgy5fetubm631n8um3Z3p49+lv/6xg75pi71L8XmtvZYSbjJmTP5PcHdOivIqIwz+U3v9U
+        chUhvy+zb9PUn9RwsMolFYyWfFJM6ouHvCIFpiLgGQ/0q8pNkh2TY3h89Pz58yfZs9JrV4C/k231
+        QJaThAeIK0LSIPliD3G2Ml5Md4JVMAROiXwm7wbv8+BtUqyz24aDIUiiknU+ik5VKAPxQhoPlxgj
+        JQo56NxbpdlNQp8UxoFiRybxmtxYwTaXzYjRFOjfXWL21m/pq9JvVY7WHCvwMsDRs0rL7wizEmqb
+        jDhHtdJMxI4VnPb393DJdZNU8KttUWQjtGMEVLbsir0VjxuhR7A4GrUw5DVNnYPeqra22cWDx+yr
+        7WNSoWdLm3GQGuIATkZ0SbvvmGawc6tHEchHaheOduZoBbfSwhv0q1jBLbcwd458BReCHl72Ec2q
+        gjPxcM1m5VRq7tA5NAQ3DQ7ZsPFwjeme/IJCrYm+iomcI3iDIWgFL2i5hI9sa5J8wLIO4yjT6Ssp
+        dpfYB9axkAy6Zb7v9SyD8VVoaYTH7MvUyTtGuUMQR4ARbjDUBAtaSqDNEMTUqHLOu8AOjp5WStO/
+        PlGUdIHjVDB1EMvU6AKtWfq4QQRccAs/Y/A0FkXOES3cOParEc6knpj3A5YUekW1X9Mi9BhGODrU
+        8IeHFRwdggIkTrnq+c2WNUGzMLwgMZYdIF9TllNsJWynTLBgZfAKoFOHK4KXDsOqDM4y2BWueV/i
+        CF+EfSH4e7JwSpjSWG3p+I4wk+iuEekYzsVZbWhGhaRG+eCywbvAUal8YxrMi5V4zwRvep8KSHO/
+        zzE49g91y9fwNIBpMKBJFHQhSJMo5kpyKf1/MTVuZfycNebzyf8wMC5Md/d3nB//SvXOwNh9+lsF
+        DzPiNXur9XxP7Z/u5bu2035+ePJHQwLtmnyeqP/nDf1sUvYdHdxI8fcCWmR2q+Ia6feGQTSByHcO
+        Cw533J3KAj6qOmduq35auKbRi7OxQGOK9OOWtnm+s/KV/V7jZfhERf/cLSgkOA0iKlevVKrgjM7J
+        U96C5o6+orcU4Fx6Z0vIO3aOWjjDpVCedipOcWfEyDJ/u6wpdDp88vwA42TwS47NtLJv4VztziSE
+        QDU6WLieIKGvN+ZnEsYKyqpHZa4ruluOUVGhm6giYwZzN23ZAyoZSxhHGHzMHwDK6sBxFTft0w8O
+        fU6hjSWHDLGEq0L1QOUzoI3klrPrCR3i4QpHOCk6dFLBdwAdpAjZ3KCldoR5/rrRrE8ppg3yyMLr
+        svNVO6pXsJlblgSsQJRc5UCGeE0WnCqzG6GTyLm0qrI0bDTXBE5sYhHYLiBPS2yLtecl6zTUPbpH
+        B+RI951YQZJeN+V6WhK8ha73phkraKmVgDrkdoQmNZhg0Cm57L0fNdOFpAZG6X0Nmb+1qOFmxnKA
+        DoPG+uEjBF0U8NJyGdxZtQIRtCrlBhPVoqtXBeyN63OBcwU/TF/GN1vyzOBfAAAA//+sme1v2zYQ
+        xv+VQ4EhNuAYfd2aj63z1iZe07pZMaBDQItn6RqK1EgqjgL0fx/uSDny0i5tsC9Fq0qkSN/9+DyP
+        XmlN3GWsBcQeL7FQdSJlRWWFgd2aSyWzLSZVTCcFJeNBMfQgSEXP75qkX+Gs3r0zmgziVrkWuNpk
+        DoguKiNu4eVvT7ZMAnsRo9esN7J9w2RLeW6yFEkZvqwiA86Ab+0djn8X47kYL3qy/iTH99z7X5++
+        XOBybz3g+PDqFsff2MDLeNfG+yh+e+cmY3lxr9AfKmmmIew7rsJU4gN9K342tfAcSzjFQ9VeYTpB
+        Xahg5pzBTprpmzCsOzhzWBke+qzqjKEAi5oipxl8pnsNJ2T1BF6TMXCsNN94imsKLBZY182Jde6J
+        MmTLCZwoiqazsE8qTPhPK9lDrqiTziDMVXGqisqoIamTYA2SAeWOKsmbTMIPZFi68aBj3oHAT10h
+        NHJK0IqVEtaO+yCIPX3+1nUwyisbT2ChtMUQYCRrG08YQh5Gsp4xS/USPYxkReP0qvsUSpbHo7Sy
+        cRpWrVZYRGA1bmglojFUabv5Wu53GPGSc7LQL3YMSn/hEVMiQ16ETGi9d60UbgC1YtHONcTdxWSb
+        k7UYXOSmgoWycOiVLSgUbpoKImUkwshhnVkwKiJ35l4e1bpIhdC9UrZEbrckcVVbVhH9Tsi7qQzF
+        rl9YySe7Mxr9IKTLM4u0TrJNo4GZ8jXaHWZIjfWS35MZJk2ef5pET49N61PQwIdDG/BWApt6Cvut
+        5/dM2iVKtND/Z60uuUgKZ9l9o4YmdEXljCspCEHAeZ0iKVVUhFeYUit+26JovSq6PBfD2fnoVZdQ
+        JacFWT2F/ZTaiCl2drirRoWYX1qqjzdAQcU2Q9T4JCeYqmm8u5ZuzoHJEIEp/Lh1YlL+K8Uq7XbJ
+        oGm1oqIVFzY8CNJZlX/Dn9C4aRkX79oo+ciLB+cj3YfzVzdH75/ZxZ8DTA6vbmHyvLkPj+fNRtru
+        PRyLd2XpUEd+l38HGl4FywPMKnYkruE2PjNtXfPFt85rZeF3VSpKc2yP+i18IXeL6WBN2q3Rc18Y
+        OPTIYeFlQAsjmXHc60qNXtB0cN0Y59HDhzYENAZGMu04Ib90CY1fXMteUnDg2lj1O7ZV+6vWrBjX
+        iiuqTjZVxfQmtdLYh7TCiDVz7MCI0/+XkIwVdlAjRj7UlRFxqN1GnrYljPq9yNREW7hWogcFJSkb
+        Yck2ND1wgldkJ31ivUQeruK7N2Eu9nswq5RnSz1vbbyBUf5BxtNeAnHITdGghmM01LJdvsNDCU7a
+        aMii9CwXGgevj5/DskdZ+p5BqRgwFKrZoFf4vq7QZlGVRbMD8p4iB5XlFI4TBdDgFdoc0+R81Udh
+        UmgYJEngadUJpP5AizctGgWlROg8Z5/pyngp5BaflopMY6DShp5UA1UqSC0U1wCr6mTQQuwM3aAW
+        UpJG1rJd+oVSP7nNk5ViA1SizsaNcZneRxkKkQp2MbHaRHyyup0wTHhZCCMHHwFtFrTP9nnLaxV/
+        XL6dN0ymx3sPJtPxp4NPF39/PF0cHAzINLy6Raa5s4F3cAJvbDG9j1Lbd8No69/ON84zpMYblD35
+        L5TV6WExYrr7P5Ld5Kn6Lw23fJNo7Mg5XSubNFwHM99x7DuBReQD8nUbCqxpkr9Dzdyy9VZMZAdH
+        tFyGHMdYSyv08JHEaMShofkOlTcSI2eoLO41Ltt8+OE1Fq2YueHa7wtovw1djs3yroa8kLMpfH60
+        aI3B7vMj4L/QFR/OLNWIH8Jd7PjQVT7aPNWSbdbKE7uSOV0ifFI3bh0uSaDFthjrxjh+bGOeYmuU
+        B04Pym43rUQYogo5qrcLR5LqooKS71cRAzRySCw7CNzEQsSai6Yioz3aKRy7NX8sS1veV474KFii
+        YY2TrWkCQ3pM3jW6ayqylWOOKTAUo8E8hejrYFFdSoiWMsL82hNRf5IPL/sUEDVU/I0qZ44UdxIP
+        +RT58Tbv9+OXp7OLN7Z4QJ/PjpalOnaqOZwP+nx49etfX7/+AwAA//8DAJSz7NIYHwAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 6ed198805c93461f-SIN
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 17 Mar 2022 00:26:12 GMT
+      Expect-CT:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Etyux5NWO8wqmRfT6C0wRYCaokbWIfra1j2xXKftjpuMou2uQBxCnjJ%2B3%2BmaySMY%2BnWjkkcfC1Ao1HELPxi9gm0iYcy9P2gxF3YH%2BLTg49K0q0YIW1WGrrgMCwjKwl%2Bu"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - tk_s=.eJyrVsrJT04syczPU7KqVkrOLKmMz0vMTVWyUvLOz8lOLElU0lFKzi_NKymqjE_OTwFJePohiUEVe-alZIKUFpcmpWSWZRYDzYs3hEmGpxaXKDil5qUn5ijV1gIA8lInvQ.FRQRpA.dd9kIxkBEEF7NV2X64lTE3rKiLQ;
+        Domain=.tastedive.com; Secure; HttpOnly; Path=/
+      Strict-Transport-Security:
+      - max-age=31536000;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Cookie
+      alt-svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
     status:
       code: 200
       message: OK

--- a/tests/test_TWP45.py
+++ b/tests/test_TWP45.py
@@ -42,7 +42,7 @@ def test_l45_3(page):
     page.keyboard.press("Backspace")
 
     instructions1 = [
-        f"solicitud_url = 'https://cors.bridged.cc/{res.url}'",
+        f"solicitud_url = 'https://api.allorigins.win/raw?url={res.url}'",
         f'resultados = {len(data["Similar"]["Results"])}',
         f"peliculas_similares = {movies}",
     ]


### PR DESCRIPTION
## Summary

This PR fixes the failing proxy in TWP45 lectures and thus closes #207 .

3 lectures under TWP45 used https://cors.bridged.cc/ proxy, which is now replaced by https://api.allorigins.win/raw?url=

Also updated **cassette** for this lecture.

## Checklist

- [x] Variables, functions and comments are translated to Spanish
- [x] Functions follow underscore notation
- [x] Spell check done & typos fixed
- [x] All python code is PEP8 compliant
- [x] Test coverage with Playwright implemented; locators are Pyhton code
- [x] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots
![99b5deef-a043-4603-a3dd-4aaa54a5f96a](https://user-images.githubusercontent.com/55462040/158714340-6143ab99-718c-4da3-abf2-a75e406b8df3.gif)

