### PR TITLE
english translation of 'Contenido'

### DIFF
--- a/_sources/lectures/TWP05/TWP05_6.rst
+++ b/_sources/lectures/TWP05/TWP05_6.rst
@@ -7,7 +7,7 @@ Tipos de variables
    :align: center
    :alt: 
 
-+ El contenido de una variable tiene un tipo
++ El Content de una variable tiene un tipo
 + El tipo define la naturaleza de los datos que almacena la variable
 + Los tipos más comunes son:
     + **Numéricas:** numeros enteros, números de coma flotante.

--- a/_sources/lectures/TWP05/toctree_en.rst
+++ b/_sources/lectures/TWP05/toctree_en.rst
@@ -11,7 +11,7 @@ Variables and Input of Data
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP10/toctree_en.rst
+++ b/_sources/lectures/TWP10/toctree_en.rst
@@ -11,7 +11,7 @@ Conditions
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP15/toctree_en.rst
+++ b/_sources/lectures/TWP15/toctree_en.rst
@@ -11,7 +11,7 @@ Repetitions
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP17/toctree_en.rst
+++ b/_sources/lectures/TWP17/toctree_en.rst
@@ -11,7 +11,7 @@ Lists
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP18/toctree_en.rst
+++ b/_sources/lectures/TWP18/toctree_en.rst
@@ -11,7 +11,7 @@ Strings
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP20/toctree_en.rst
+++ b/_sources/lectures/TWP20/toctree_en.rst
@@ -11,7 +11,7 @@ for, random and functions
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP23/toctree_en.rst
+++ b/_sources/lectures/TWP23/toctree_en.rst
@@ -11,7 +11,7 @@ Files and dictionaries
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP25/toctree_en.rst
+++ b/_sources/lectures/TWP25/toctree_en.rst
@@ -11,7 +11,7 @@ Classes and objects
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP30/toctree_en.rst
+++ b/_sources/lectures/TWP30/toctree_en.rst
@@ -11,7 +11,7 @@ General review 1
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP33/toctree_en.rst
+++ b/_sources/lectures/TWP33/toctree_en.rst
@@ -17,7 +17,7 @@ String Review
 + Y aprenderemos uno de los conceptos más importantes de orientación a la objetos: métodos
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP35/toctree_en.rst
+++ b/_sources/lectures/TWP35/toctree_en.rst
@@ -11,7 +11,7 @@ Function Review
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP37/toctree_en.rst
+++ b/_sources/lectures/TWP37/toctree_en.rst
@@ -11,7 +11,7 @@ File, List, and Dictionary Review
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP38/toctree_en.rst
+++ b/_sources/lectures/TWP38/toctree_en.rst
@@ -11,7 +11,7 @@ General review 2
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP40/TWP40_2.rst
+++ b/_sources/lectures/TWP40/TWP40_2.rst
@@ -9,7 +9,7 @@ Variables
 Variables con valores definidos e indefinidos
 ---------------------------------------------
 
-+ Solo se puede usar el contenido de una variable si ya tiene un valor *definido* antes.
++ Solo se puede usar el Content de una variable si ya tiene un valor *definido* antes.
 + Si se usa variable que no tiene valor definido o se encuentra *indefinido* daría como resultado un error como el siguiente.
 
 .. activecode:: ac_l40_2

--- a/_sources/lectures/TWP40/toctree_en.rst
+++ b/_sources/lectures/TWP40/toctree_en.rst
@@ -11,7 +11,7 @@ General review 3
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP42/TWP42_2.rst
+++ b/_sources/lectures/TWP42/TWP42_2.rst
@@ -90,7 +90,7 @@ Accediendo a la base alumnos.bd
    cur.execute('insert into alumnos values("masanori",421)')
    cur.execute('insert into alumnos values("emengarda",666)')
 
-   # selecciona todo el contenido de la tabla de alumnos
+   # selecciona todo el Content de la tabla de alumnos
    cur.execute('select * from alumnos')
 
    result = cur.fetchall()

--- a/_sources/lectures/TWP42/toctree_en.rst
+++ b/_sources/lectures/TWP42/toctree_en.rst
@@ -11,7 +11,7 @@ Databases
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP45/toctree_en.rst
+++ b/_sources/lectures/TWP45/toctree_en.rst
@@ -10,7 +10,7 @@ Hacking with Python
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP47/toctree_en.rst
+++ b/_sources/lectures/TWP47/toctree_en.rst
@@ -11,7 +11,7 @@ Modules
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP50/toctree_en.rst
+++ b/_sources/lectures/TWP50/toctree_en.rst
@@ -11,7 +11,7 @@ Graphical User Interface
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP54/toctree_en.rst
+++ b/_sources/lectures/TWP54/toctree_en.rst
@@ -11,7 +11,7 @@ Exceptions
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP56/toctree_en.rst
+++ b/_sources/lectures/TWP56/toctree_en.rst
@@ -11,7 +11,7 @@ DJ Mix 1
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP58/toctree_en.rst
+++ b/_sources/lectures/TWP58/toctree_en.rst
@@ -11,7 +11,7 @@ DJ Mix 2 revisión orientada a objetos
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP60/toctree_en.rst
+++ b/_sources/lectures/TWP60/toctree_en.rst
@@ -11,7 +11,7 @@ Pygame
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 

--- a/_sources/lectures/TWP65/toctree_en.rst
+++ b/_sources/lectures/TWP65/toctree_en.rst
@@ -11,7 +11,7 @@ Introduction to Web Development
 
 
 .. toctree::
-   :caption: Contenido
+   :caption: Content
    :maxdepth: 1
    :numbered:
 


### PR DESCRIPTION
## Summary
This pull request replaces the `Contenido` with its English-translated word `Content` In `toctree_en.rst` Files.
closes #303 

## Preview
![image](https://github.com/PyAr/PyZombis/assets/100200105/a6235520-2389-4494-94f4-80e32c09b7df)


