### PR TITLE
updates dj mix app to run in the browser without using pc

### DIFF
--- a/_sources/lectures/TWP56/TWP56_1.rst
+++ b/_sources/lectures/TWP56/TWP56_1.rst
@@ -8,28 +8,32 @@ DJ Mix
    :align: center
    :alt: 
 
+.. activecode:: lecture_56_1_es
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-.. code-block :: python
+   from browser import document, html
 
-   from tkinter import *
-   import pygame.mixer
-
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
-
-   som = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
+   audio_url = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
 
    def start():
-      track.play(loops = -1)
-   def stop():
-      track.stop()
+      document['track'].play()
+      print("Audio iniciado")
 
-   track = mixer.Sound(som)
-   start_botao = Button(app, command = start, text = 'Start')
-   start_botao.pack(side = LEFT)
-   stop_botao = Button(app, command = stop, text = 'Stop')
-   stop_botao.pack(side = RIGHT)
-   app.mainloop()
+   def stop():
+      document['track'].pause()
+      document['track'].currentTime = 0
+      print("Audio detenido")
+
+   audio_element = html.AUDIO(id='track', src=audio_url)
+   document <= audio_element
+
+   start_button = html.BUTTON('Iniciar')
+   start_button.bind('click', lambda ev: start())
+
+   stop_button = html.BUTTON('Detener')
+   stop_button.bind('click', lambda ev: stop())
+
+   document <= start_button
+   document <= stop_button

--- a/_sources/lectures/TWP56/TWP56_1_en.rst
+++ b/_sources/lectures/TWP56/TWP56_1_en.rst
@@ -8,29 +8,33 @@ DJ Mix
    :align: center
    :alt: 
 
+.. activecode:: lecture_56_1_en
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-.. code-block:: python
+   from browser import document, html
 
-   from tkinter import *
-   import pygame.mixer
-
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
-
-   som = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
+   audio_url = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
 
    def start():
-      track.play(loops=-1)
-   
-   def stop():
-      track.stop()
+      document['track'].play()
+      print("Audio started")
 
-   track = mixer.Sound(som)
-   start_button = Button(app, command=start, text='Start')
-   start_button.pack(side=LEFT)
-   stop_button = Button(app, command=stop, text='Stop')
-   stop_button.pack(side=RIGHT)
-   app.mainloop()
+   def stop():
+      document['track'].pause()
+      document['track'].currentTime = 0
+      print("Audio stopped")
+
+   audio_element = html.AUDIO(id='track', src=audio_url)
+   document <= audio_element
+
+   start_button = html.BUTTON('Start')
+   start_button.bind('click', lambda ev: start())
+
+   stop_button = html.BUTTON('Stop')
+   stop_button.bind('click', lambda ev: stop())
+
+   document <= start_button
+   document <= stop_button
+   

--- a/_sources/lectures/TWP56/TWP56_2.rst
+++ b/_sources/lectures/TWP56/TWP56_2.rst
@@ -9,36 +9,48 @@ Pero la canción no termina...
    :alt: 
 
 
-.. code-block :: python
+.. activecode:: lec56es1fdarhg
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-   from tkinter import *
-   import pygame.mixer
+   from browser import document, html
 
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
+   sonido = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
 
-   som = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
+   def iniciar():
+      pista.play()
+      print("Audio iniciado")
 
-   def start():
-      track.play(loops = -1)
-   def stop():
-      track.stop()
-   def termina():
-      track.stop()
-      app.destroy()
+   def detener():
+      pista.pause()
+      pista.currentTime = 0
+      print("Audio detenido")
 
-   track = mixer.Sound(som)
-   start_botao = Button(app, command = start, text = 'Start')
-   start_botao.pack(side = LEFT)
-   stop_botao = Button(app, command = stop, text = 'Stop')
-   stop_botao.pack(side = RIGHT)
+   def terminar(ev):
+      pista.pause()
+      if app_div in document:
+         app_div.remove()
+      print("Aplicación terminada")
 
-   app.protocol('WM_DELETE_WINDOW',terminal)
-   app.mainloop()
+   elemento_audio = html.AUDIO(src=sonido)
 
+   boton_iniciar = html.BUTTON('Iniciar')
+   boton_iniciar.bind('click', lambda ev: iniciar())
+
+   boton_detener = html.BUTTON('Detener')
+   boton_detener.bind('click', lambda ev: detener())
+
+   app_div = html.DIV()
+   app_div <= elemento_audio
+   app_div <= boton_iniciar
+   app_div <= boton_detener
+
+   document <= app_div
+
+   document.bind('beforeunload', terminar)
+
+   pista = elemento_audio
 
 Un solo botón
 -------------
@@ -50,32 +62,40 @@ Un solo botón
    :alt: 
 
 
-.. code-block :: python
+.. activecode:: lecture_56_2_es
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-   from tkinter import *
-   import pygame.mixer
+   from browser import document, html
 
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
+   sonido = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
 
-   som = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
+   def terminar():
+      pista.pause()
+      if app_div in document:
+         app_div.remove()
 
-   def termina():
-      track.stop()
-      app.destroy()
-   def muda():
-      if tocando.get() == 1:
-         track.play(loops = -1)
+   def cambiar(ev):
+      if ev.target.checked:
+         pista.play()
       else:
-         track.stop()
+         pista.pause()
 
-   track = mixer.Sound(som)
-   tocando = IntVar()
-   tocar = Checkbutton(app,variable = tocando, command = muda, text = som)
-   tocar.pack()
+   elemento_audio = html.AUDIO(src=sonido)
 
-   app.protocol('WM_DELETE_WINDOW',terminal)
-   app.mainloop()
+   boton_reproduccion = html.INPUT(type='checkbox')
+   etiqueta_reproduccion = html.LABEL('Reproducir sonido', style={'margin-left': '10px'})
+   etiqueta_reproduccion <= boton_reproduccion
+
+   app_div = html.DIV()
+   app_div <= elemento_audio
+   app_div <= etiqueta_reproduccion
+
+   document <= app_div
+
+   boton_reproduccion.bind('change', cambiar)
+
+   document.bind('beforeunload', terminar)
+
+   pista = elemento_audio

--- a/_sources/lectures/TWP56/TWP56_2_en.rst
+++ b/_sources/lectures/TWP56/TWP56_2_en.rst
@@ -8,35 +8,48 @@ But the song never ends...
    :alt: 
 
 
-.. code-block :: python
+.. activecode:: lecture_56_2_en
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-   from tkinter import *
-   import pygame.mixer
+   from browser import document, html
 
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
-
-   sound = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
+   sound = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
 
    def start():
-      track.play(loops = -1)
+      track.play()
+      print("Audio started")
+
    def stop():
-      track.stop()
-   def terminate():
-      track.stop()
-      app.destroy()
+      track.pause()
+      track.currentTime = 0
+      print("Audio stopped")
 
-   track = mixer.Sound(sound)
-   start_button = Button(app, command = start, text = 'Start')
-   start_button.pack(side = LEFT)
-   stop_button = Button(app, command = stop, text = 'Stop')
-   stop_button.pack(side = RIGHT)
+   def terminate(ev):
+      track.pause()
+      if app_div in document:
+         app_div.remove()
+      print("Application terminated")
 
-   app.protocol('WM_DELETE_WINDOW',terminate)
-   app.mainloop()
+   audio_element = html.AUDIO(src=sound)
+
+   start_button = html.BUTTON('Start')
+   start_button.bind('click', lambda ev: start())
+
+   stop_button = html.BUTTON('Stop')
+   stop_button.bind('click', lambda ev: stop())
+
+   app_div = html.DIV()
+   app_div <= audio_element
+   app_div <= start_button
+   app_div <= stop_button
+
+   document <= app_div
+
+   document.bind('beforeunload', terminate)
+
+   track = audio_element
 
 
 One button only
@@ -49,32 +62,41 @@ One button only
    :alt: 
 
 
-.. code-block :: python
+.. activecode:: lec56esdgdbf
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-   from tkinter import *
-   import pygame.mixer
+   from browser import document, html
 
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
-
-   sound = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
+   sound = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
 
    def terminate():
-      track.stop()
-      app.destroy()
-   def switch():
-      if playing.get() == 1:
-         track.play(loops = -1)
+      track.pause()
+      if app_div in document:
+         app_div.remove()
+
+   def switch(ev):
+      if ev.target.checked:
+         track.play()
       else:
-         track.stop()
+         track.pause()
 
-   track = mixer.Sound(sound)
-   playing = IntVar()
-   play_button = Checkbutton(app, variable = playing, command = switch, text = sound)
-   play_button.pack()
+   audio_element = html.AUDIO(src=sound)
 
-   app.protocol('WM_DELETE_WINDOW',terminate)
-   app.mainloop()
+   play_button = html.INPUT(type='checkbox')
+   play_label = html.LABEL('Play Sound', style={'margin-left': '10px'})
+   play_label <= play_button
+
+   app_div = html.DIV()
+   app_div <= audio_element
+   app_div <= play_label
+
+   document <= app_div
+
+   play_button.bind('change', switch)
+
+   document.bind('beforeunload', terminate)
+
+   track = audio_element
+

--- a/_sources/lectures/TWP56/TWP56_3.rst
+++ b/_sources/lectures/TWP56/TWP56_3.rst
@@ -8,41 +8,43 @@ Se ve genial, ¡ahora agreguemos un volumen!
    :alt: 
 
 
-.. code-block :: python
+.. activecode:: lect_56_3_es
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-   from tkinter import *
-   import pygame.mixer
+   from browser import document, html
 
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
-
-   som = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
-
-   def termina():
-      track.stop()
-      app.destroy()
-   def muda():
-      if tocando.get() == 1:
-         track.play(loops = -1)
+   def toggle_play(ev):
+      if ev.target.checked:
+         document['audio_player'].play()
       else:
-         track.stop()
-   def muda_volume(v):
-      track.set_volume(volume.get())
+         document['audio_player'].pause()
 
-   track = mixer.Sound(som)
-   tocando = IntVar()
-   tocar = Checkbutton(app,variable = tocando, command = muda, text = som)
-   tocar.pack(side = LEFT)
-   volume = DoubleVar()
-   volume.set(track.get_volume())
-   escala = Scale(variable = volume , from = 0.0 , to = 1.0 , resolution = 0.1, command = muda_volume, label = 'Volume',orient = HORIZONTAL)
+   def change_volume(ev):
+      document['audio_player'].volume = float(ev.target.value)
 
-   escala.pack(side = RIGHT)
-   app.protocol('WM_DELETE_WINDOW',terminal)
-   app.mainloop()
+   audio_src = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
+
+   audio_player = html.AUDIO(src=audio_src, id='audio_player')
+
+   toggle_button = html.INPUT(type='checkbox', id='toggle_play')
+   toggle_button.bind('change', toggle_play)
+   toggle_label = html.LABEL('Reproducir sonido')
+   toggle_label <= toggle_button
+
+   volume_slider = html.INPUT(type='range', id='volume', min='0', max='1', step='0.1')
+   volume_slider.bind('input', change_volume)
+   volume_label = html.LABEL('Volumen')
+   volume_label <= volume_slider
+
+   app_div = html.DIV(id='app')
+   app_div <= audio_player
+   app_div <= toggle_label
+   app_div <= volume_label
+
+   document <= app_div
+
 
 
 .. image:: ../img/TWP56_010.jpg

--- a/_sources/lectures/TWP56/TWP56_3_en.rst
+++ b/_sources/lectures/TWP56/TWP56_3_en.rst
@@ -8,42 +8,42 @@ It looks great, now let's add some volume!
    :alt: 
 
 
-.. code-block :: python
+.. activecode:: lecture_56_3_en
+   :nocodelens:
+   :language: python3
+   :python3_interpreter: brython
 
-   from tkinter import *
-   import pygame.mixer
+   from browser import document, html
 
-   app = Tk()
-   app.title('DJ Mix')
-   app.geometry('250x100+200+100')
-
-   som = '50459_M_RED_Nephlimizer.wav'
-   mixer = pygame.mixer
-   mixer.init()
-
-   def terminate():
-      track.stop()
-      app.destroy()
-   def toggle_play():
-      if playing.get() == 1:
-         track.play(loops = -1)
+   def toggle_play(ev):
+      if ev.target.checked:
+         document['audio_player'].play()
       else:
-         track.stop()
-   def change_volume(v):
-      track.set_volume(volume.get())
+         document['audio_player'].pause()
 
-   track = mixer.Sound(som)
-   playing = IntVar()
-   toggle = Checkbutton(app, variable=playing, command=toggle_play, text=som)
-   toggle.pack(side=LEFT)
-   volume = DoubleVar()
-   volume.set(track.get_volume())
-   scale = Scale(variable=volume, from_=0.0, to=1.0, resolution=0.1, command=change_volume, label='Volume', orient=HORIZONTAL)
+   def change_volume(ev):
+      document['audio_player'].volume = float(ev.target.value)
 
-   scale.pack(side=RIGHT)
-   app.protocol('WM_DELETE_WINDOW', terminate)
-   app.mainloop()
+   audio_src = 'https://bigsoundbank.com/UPLOAD/mp3/0751.mp3'
 
+   audio_player = html.AUDIO(src=audio_src, id='audio_player')
+
+   toggle_button = html.INPUT(type='checkbox', id='toggle_play')
+   toggle_button.bind('change', toggle_play)
+   toggle_label = html.LABEL('Play Sound')
+   toggle_label <= toggle_button
+
+   volume_slider = html.INPUT(type='range', id='volume', min='0', max='1', step='0.1')
+   volume_slider.bind('input', change_volume)
+   volume_label = html.LABEL('Volume')
+   volume_label <= volume_slider
+
+   app_div = html.DIV(id='app')
+   app_div <= audio_player
+   app_div <= toggle_label
+   app_div <= volume_label
+
+   document <= app_div
 
 .. image:: ../img/TWP56_010.jpg
    :height: 15.024cm


### PR DESCRIPTION
## Summary
#218 the original lessons use tkinter which requires pc to run, I solved that issue making the code running natively in browser. 

partially closes for pages 
lec/56_1
lec/56_2
lec/56_3, for both english and spanish.

(short description of what does this PR, Issue #, etc.)

## Checklist

- [ ] Variables, functions and comments are translated to Spanish
- [ ] Functions follow underscore notation
- [ ] Spell check done & typos fixed
- [ ] All python code is PEP8 compliant
- [ ] Test coverage with Playwright implemented; locators are Pyhton code
- [ ] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots

(prefer Playwright recorded video or animated gif)
