### PR TITLE
 the elif clause formatting is fixed and closes the issue #337

### DIFF
--- a/_sources/lectures/TWP10/TWP10_5_en.rst
+++ b/_sources/lectures/TWP10/TWP10_5_en.rst
@@ -44,5 +44,5 @@ Nested Structures
     print("Telephone bill : $%6.2f" % (minutes * price))
 
 + Note that nested structures can grow.
-+ Python, given its characteristics, provides the "elif" clause.
++ Python, given its characteristics, provides the ``elif`` clause.
 + It is used to check multiple conditions.


### PR DESCRIPTION
## Summary

the elif formatting is corrected properly and this fixes the issue

## Screenshots

![Screenshot 2024-03-13 at 4 39 32 PM](https://github.com/PyAr/PyZombis/assets/89120140/7df7a66f-df99-4cf1-b562-5e82e6ed17b5)
![Screenshot 2024-03-14 at 2 10 55 AM](https://github.com/PyAr/PyZombis/assets/89120140/d39f389e-3724-42d3-96e5-c12f3c030580)

(prefer Playwright recorded video or animated gif)
