### PR TITLE
 the elif clause formatting is fixed and closes the issue #337 Open @adityaJoshi07

### DIFF
--- a/_sources/lectures/TWP10/TWP10_5_en.rst
+++ b/_sources/lectures/TWP10/TWP10_5_en.rst
@@ -44,5 +44,5 @@ Nested Structures
     print("Telephone bill : $%6.2f" % (minutes * price))
 
 + Note that nested structures can grow.
-+ Python, given its characteristics, provides the "elif" clause.
++ Python, given its characteristics, provides the ``elif`` clause.
 + It is used to check multiple conditions.


### PR DESCRIPTION
## Summary

the elif formatting is corrected properly and this fixes the issue https://github.com/PyAr/PyZombis/issues/337

## Checklist

- [ ] Variables, functions and comments are translated to Spanish
- [ ] Functions follow underscore notation
- [ ] Spell check done & typos fixed
- [ ] All python code is PEP8 compliant
- [ ] Test coverage with Playwright implemented; locators are Pyhton code
- [ ] Reviewers assigned (all peers & at least 1 mentor)

## Screenshots
![a1](https://github.com/user-attachments/assets/6fadc5e6-0483-4fd2-b0b3-1c27e72b9e7d)

(prefer Playwright recorded video or animated gif)
